### PR TITLE
Add group balance screen

### DIFF
--- a/BaseStyle/BaseStyle/Resource/AppColors.swift
+++ b/BaseStyle/BaseStyle/Resource/AppColors.swift
@@ -34,3 +34,4 @@ public let inverseSurfaceColor = Color.inverseSurface
 
 public let amountLentColor = Color.amountLent
 public let amountBorrowedColor = Color.amountBorrowed
+public let settleUpColor = Color.settleUp

--- a/BaseStyle/BaseStyle/Resource/BaseAssets.xcassets/Colors/SettleUpColor.colorset/Contents.json
+++ b/BaseStyle/BaseStyle/Resource/BaseAssets.xcassets/Colors/SettleUpColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x28",
+          "green" : "0x60",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Data/Data/Model/Groups.swift
+++ b/Data/Data/Model/Groups.swift
@@ -18,7 +18,7 @@ public struct Groups: Codable, Identifiable, Hashable {
     public var createdAt: Timestamp
     public var isDebtSimplified: Bool
 
-    public init(name: String, createdBy: String, members: [String], imageUrl: String? = nil, createdAt: Timestamp, isDebtSimplified: Bool = false) {
+    public init(name: String, createdBy: String, members: [String], imageUrl: String? = nil, createdAt: Timestamp, isDebtSimplified: Bool = true) {
         self.name = name
         self.createdBy = createdBy
         self.members = members

--- a/Splito.xcodeproj/project.pbxproj
+++ b/Splito.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		07BE3EA39C276BF8B8A47841 /* Pods_SplitoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA3D6F970A1B86FF3657777F /* Pods_SplitoTests.framework */; };
 		0E8518C2A50B4013739F462C /* Pods_Splito.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EED68AA3D71C6AAF6B6DDE27 /* Pods_Splito.framework */; };
 		1AA0888605B3C007D521672B /* Pods_Splito_SplitoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F43B44CC4843658DFC543F9 /* Pods_Splito_SplitoUITests.framework */; };
+		D826C0E22BDBD65600AAA449 /* GroupBalancesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826C0E12BDBD65600AAA449 /* GroupBalancesView.swift */; };
+		D826C0E42BDBD66300AAA449 /* GroupBalancesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826C0E32BDBD66300AAA449 /* GroupBalancesViewModel.swift */; };
 		D8302DA02B9F282F005ACA13 /* InviteMemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8302D9F2B9F282F005ACA13 /* InviteMemberView.swift */; };
 		D8302DA22B9F284D005ACA13 /* InviteMemberViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8302DA12B9F284D005ACA13 /* InviteMemberViewModel.swift */; };
 		D856C7322BCFD21C0008A341 /* ExpenseDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D856C7312BCFD21C0008A341 /* ExpenseDetailsView.swift */; };
@@ -114,6 +116,8 @@
 		D7D95533332DF3C305CBF7CC /* Pods-Splito.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Splito.release.xcconfig"; path = "Target Support Files/Pods-Splito/Pods-Splito.release.xcconfig"; sourceTree = "<group>"; };
 		D8015C042B7A47CF0002886A /* Data.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Data.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8015C082B7A47D80002886A /* UI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D826C0E12BDBD65600AAA449 /* GroupBalancesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBalancesView.swift; sourceTree = "<group>"; };
+		D826C0E32BDBD66300AAA449 /* GroupBalancesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBalancesViewModel.swift; sourceTree = "<group>"; };
 		D8302D9F2B9F282F005ACA13 /* InviteMemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMemberView.swift; sourceTree = "<group>"; };
 		D8302DA12B9F284D005ACA13 /* InviteMemberViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMemberViewModel.swift; sourceTree = "<group>"; };
 		D856C7312BCFD21C0008A341 /* ExpenseDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseDetailsView.swift; sourceTree = "<group>"; };
@@ -238,6 +242,15 @@
 				793653EBCA3CC65682066781 /* Pods-SplitoTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		D826C0E02BDBD63A00AAA449 /* Group Options */ = {
+			isa = PBXGroup;
+			children = (
+				D826C0E12BDBD65600AAA449 /* GroupBalancesView.swift */,
+				D826C0E32BDBD66300AAA449 /* GroupBalancesViewModel.swift */,
+			);
+			path = "Group Options";
 			sourceTree = "<group>";
 		};
 		D8302D9D2B9F2770005ACA13 /* Create Group */ = {
@@ -413,6 +426,7 @@
 			children = (
 				D8A7CA6D2BA483F60014EC67 /* GroupHomeView.swift */,
 				D8E244BE2B98592C00C6C82A /* GroupHomeViewModel.swift */,
+				D826C0E02BDBD63A00AAA449 /* Group Options */,
 				D8A7CA732BA486290014EC67 /* Group Setting */,
 			);
 			path = Group;
@@ -782,12 +796,14 @@
 				D8AC26F32B84B12800CEAAD3 /* OnboardView.swift in Sources */,
 				D8D6C3A02B79F8110023CF08 /* AppDelegate.swift in Sources */,
 				D8AC26F42B84B12800CEAAD3 /* OnboardViewModel.swift in Sources */,
+				D826C0E42BDBD66300AAA449 /* GroupBalancesViewModel.swift in Sources */,
 				D89DBE3A2B88A6B400E5F1BD /* VerifyOtpViewModel.swift in Sources */,
 				D89DBE5F2B8DE98600E5F1BD /* AccountRouteView.swift in Sources */,
 				D8CD952C2BD65F1900407B47 /* ExpenseSplitOptionsView.swift in Sources */,
 				D8D14A652BA2DD7300F45FF2 /* UserProfileImageView.swift in Sources */,
 				D89C933B2BC0204100FACD16 /* AccountHomeView.swift in Sources */,
 				D8D14A672BA2E25100F45FF2 /* UserProfileList.swift in Sources */,
+				D826C0E22BDBD65600AAA449 /* GroupBalancesView.swift in Sources */,
 				D85E86E72BB2E189002EDF76 /* ExpenseRouteView.swift in Sources */,
 				D8302DA02B9F282F005ACA13 /* InviteMemberView.swift in Sources */,
 				D89684452B722D3400D5F721 /* SplitoApp.swift in Sources */,

--- a/Splito/UI/Home/Groups/Group/Group Options/GroupBalancesView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/GroupBalancesView.swift
@@ -1,0 +1,157 @@
+//
+//  GroupBalancesView.swift
+//  Splito
+//
+//  Created by Amisha Italiya on 26/04/24.
+//
+
+import SwiftUI
+import Data
+import BaseStyle
+
+struct GroupBalancesView: View {
+
+    @ObservedObject var viewModel: GroupBalancesViewModel
+
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            if case .loading = viewModel.viewState {
+                LoaderView()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Divider()
+                            .frame(height: 1)
+                            .background(outlineColor.opacity(0.4))
+
+                        VSpacer(50)
+
+                        VStack(alignment: .leading, spacing: 16) {
+                            ForEach(viewModel.memberBalances, id: \.id) { memberBalance in
+                                GroupBalanceItemView(memberBalance: memberBalance, viewModel: viewModel, toggleExpandBtn: viewModel.handleBalanceExpandView(id:))
+
+                                Divider()
+                                    .frame(height: 1)
+                                    .background(outlineColor)
+                            }
+                        }
+                    }
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .background(backgroundColor)
+        .interactiveDismissDisabled()
+        .toastView(toast: $viewModel.toast)
+        .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
+        .navigationBarTitle("Group balances", displayMode: .inline)
+        .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") {
+                    dismiss()
+                }
+            }
+        }
+    }
+}
+
+private struct GroupBalanceItemView: View {
+
+    let memberBalance: GroupMemberBalance
+    let viewModel: GroupBalancesViewModel
+
+    let toggleExpandBtn: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 15) {
+                let mainImageHeight: CGFloat = 50
+                let imageUrl = viewModel.getMemberImage(id: memberBalance.id)
+                MemberProfileImageView(imageUrl: imageUrl, height: mainImageHeight)
+
+                let hasDue = memberBalance.totalOwedAmount < 0
+                let name = viewModel.getMemberName(id: memberBalance.id, needFullName: true)
+                let owesOrGetsBack = hasDue ? "owes" : "gets back"
+                Group {
+                    Text(name)
+                        .font(.Header4())
+
+                    + Text(" \(owesOrGetsBack) ")
+
+                    + Text(memberBalance.totalOwedAmount.formattedCurrency)
+                        .font(.body1(17))
+                        .foregroundColor(hasDue ? amountBorrowedColor : amountLentColor)
+
+                    + Text(" in total")
+                }
+                .lineSpacing(3)
+                .font(.body1(16))
+                .foregroundStyle(primaryText)
+
+                Spacer()
+
+                Image(systemName: memberBalance.isExpanded ? "rectangle.compress.vertical" : "rectangle.expand.vertical")
+                    .resizable()
+                    .frame(width: 18, height: 18)
+                    .foregroundStyle(secondaryText.opacity(0.8))
+                    .onTouchGesture {
+                        withAnimation(Animation.easeInOut(duration: 0.3)) {
+                            toggleExpandBtn(memberBalance.id)
+                        }
+                    }
+            }
+            .padding(.horizontal, 15)
+
+            if memberBalance.isExpanded {
+                GroupBalanceItemMemberView(id: memberBalance.id, balances: memberBalance.balances, viewModel: viewModel)
+            }
+        }
+    }
+}
+
+private struct GroupBalanceItemMemberView: View {
+
+    let id: String
+    let balances: [String: Double]
+    let viewModel: GroupBalancesViewModel
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 15) {
+            let mainImageHeight: CGFloat = 50
+            HSpacer(mainImageHeight)
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(balances.sorted(by: { $0.key < $1.key }), id: \.key) { (memberId, amount) in
+                    let hasDue = amount < 0
+                    let imageUrl = viewModel.getMemberImage(id: hasDue ? id : memberId)
+                    let owesMemberName = viewModel.getMemberName(id: hasDue ? memberId : id)
+                    let owedMemberName = viewModel.getMemberName(id: hasDue ? id : memberId)
+
+                    HStack(alignment: .center, spacing: 10) {
+                        let subImageHeight: CGFloat = 36
+                        MemberProfileImageView(imageUrl: imageUrl, height: subImageHeight)
+
+                        Group {
+                            Text("\(owedMemberName) owes ")
+
+                            + Text(amount.formattedCurrency)
+                                .foregroundColor(hasDue ? amountBorrowedColor : amountLentColor)
+
+                            + Text(" to \(owesMemberName)")
+                        }
+                        .font(.body1(16))
+                        .foregroundStyle(secondaryText)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+    }
+}
+
+#Preview {
+    GroupBalancesView(viewModel: GroupBalancesViewModel(groupId: ""))
+}

--- a/Splito/UI/Home/Groups/Group/Group Options/GroupBalancesViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/GroupBalancesViewModel.swift
@@ -1,0 +1,221 @@
+//
+//  GroupBalancesViewModel.swift
+//  Splito
+//
+//  Created by Amisha Italiya on 26/04/24.
+//
+
+import Data
+import Foundation
+
+class GroupBalancesViewModel: BaseViewModel, ObservableObject {
+
+    @Inject var preference: SplitoPreference
+    @Inject var groupRepository: GroupRepository
+    @Inject var expenseRepository: ExpenseRepository
+
+    @Published var viewState: ViewState = .initial
+    @Published var memberBalances: [GroupMemberBalance] = []
+    @Published var memberOwingAmount: [String: Double] = [:]
+
+    private let groupId: String
+    private var groupMemberData: [AppUser] = []
+
+    init(groupId: String) {
+        self.groupId = groupId
+        super.init()
+        fetchGroupMembers(groupId: groupId)
+    }
+
+    private func fetchGroupMembers(groupId: String) {
+        viewState = .loading
+        groupRepository.fetchMembersBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.viewState = .initial
+                    self?.showToastFor(error)
+                }
+            } receiveValue: { users in
+                self.groupMemberData = users
+                self.fetchGroupAndExpenses()
+            }.store(in: &cancelable)
+    }
+
+    private func fetchGroupAndExpenses() {
+        groupRepository.fetchGroupBy(id: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.viewState = .initial
+                    self?.showToastFor(error)
+                }
+            } receiveValue: { [weak self] group in
+                guard let self, let group else { return }
+                self.fetchExpenses(group: group)
+            }.store(in: &cancelable)
+    }
+
+    private func fetchExpenses(group: Groups) {
+        expenseRepository.fetchExpensesBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.viewState = .initial
+                    self?.showToastFor(error)
+                }
+            } receiveValue: { [weak self] expenses in
+                guard let self else { return }
+                if group.isDebtSimplified {
+                    calculateExpensesSimply(expenses: expenses)
+                } else {
+                    calculateExpenses(expenses: expenses)
+                }
+            }.store(in: &cancelable)
+    }
+
+    private func calculateExpenses(expenses: [Expense]) {
+        let groupMembers = Array(Set(expenses.flatMap { $0.splitTo + [$0.paidBy] }))
+        var memberBalances = groupMembers.map { GroupMemberBalance(id: $0) }
+
+        for expense in expenses {
+            let splitAmount = expense.amount / Double(expense.splitTo.count)
+
+            if let paidByIndex = memberBalances.firstIndex(where: { $0.id == expense.paidBy }) {
+                memberBalances[paidByIndex].totalOwedAmount += expense.amount
+
+                for member in expense.splitTo {
+                    if let owedMemberIndex = memberBalances.firstIndex(where: { $0.id == member }) {
+                        memberBalances[owedMemberIndex].totalOwedAmount -= splitAmount
+                        if member != expense.paidBy {
+                            memberBalances[owedMemberIndex].balances[expense.paidBy, default: 0.0] -= splitAmount
+                            memberBalances[paidByIndex].balances[member, default: 0.0] += splitAmount
+                        }
+                    }
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.sortMemberBalances(memberBalances: memberBalances)
+        }
+    }
+
+    private func calculateExpensesSimply(expenses: [Expense]) {
+        let groupMembers = Array(Set(expenses.flatMap { $0.splitTo + [$0.paidBy] }))
+        var memberBalances = groupMembers.map { GroupMemberBalance(id: $0) }
+
+        for expense in expenses {
+            let splitAmount = expense.amount / Double(expense.splitTo.count)
+
+            if let paidByIndex = memberBalances.firstIndex(where: { $0.id == expense.paidBy }) {
+                memberBalances[paidByIndex].totalOwedAmount += expense.amount
+            }
+
+            for member in expense.splitTo {
+                if let owedMemberIndex = memberBalances.firstIndex(where: { $0.id == member }) {
+                    memberBalances[owedMemberIndex].totalOwedAmount -= splitAmount
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            let debts = self.settleDebts(balances: memberBalances)
+            self.sortMemberBalances(memberBalances: debts)
+        }
+    }
+
+    private func settleDebts(balances: [GroupMemberBalance]) -> [GroupMemberBalance] {
+        var creditors: [(GroupMemberBalance, Double)] = []
+        var debtors: [(GroupMemberBalance, Double)] = []
+
+        // Separate users into creditors and debtors
+        for balance in balances {
+            if balance.totalOwedAmount > 0 {
+                creditors.append((balance, balance.totalOwedAmount))
+            } else if balance.totalOwedAmount < 0 {
+                debtors.append((balance, -balance.totalOwedAmount)) // Store as positive for ease of calculation
+            }
+        }
+
+        // Sort creditors and debtors by the amount they owe or are owed
+        creditors.sort { $0.1 < $1.1 }
+        debtors.sort { $0.1 < $1.1 }
+
+        var updatedBalances = balances
+
+        while !creditors.isEmpty && !debtors.isEmpty { // Process all debts
+            let (creditor, credAmt) = creditors.removeFirst()
+            let (debtor, debtAmt) = debtors.removeFirst()
+            let minAmt = min(credAmt, debtAmt)
+
+            // Update the balances
+            if let creditorIndex = updatedBalances.firstIndex(where: { $0.id == creditor.id }) {
+                updatedBalances[creditorIndex].balances[debtor.id, default: 0.0] += minAmt
+            }
+
+            if let debtorIndex = updatedBalances.firstIndex(where: { $0.id == debtor.id }) {
+                updatedBalances[debtorIndex].balances[creditor.id, default: 0.0] -= minAmt
+            }
+
+            // Reinsert any remaining balances
+            if credAmt > debtAmt {
+                creditors.insert((creditor, credAmt - debtAmt), at: 0)
+            } else if debtAmt > credAmt {
+                debtors.insert((debtor, debtAmt - credAmt), at: 0)
+            }
+        }
+        return updatedBalances
+    }
+
+    private func sortMemberBalances(memberBalances: [GroupMemberBalance]) {
+        guard let userId = preference.user?.id, let userIndex = memberBalances.firstIndex(where: { $0.id == userId }) else { return }
+
+        var sortedMembers = memberBalances
+
+        var userBalance = sortedMembers.remove(at: userIndex)
+        userBalance.isExpanded = true
+        sortedMembers.insert(userBalance, at: 0)
+
+        sortedMembers.sort { member1, member2 in
+            if member1.id == userId { true } else if member2.id == userId { false }
+            else { getMemberName(id: member1.id) < getMemberName(id: member2.id) }
+        }
+
+        self.memberBalances = sortedMembers
+        self.viewState = .initial
+    }
+
+    private func getMemberDataBy(id: String) -> AppUser? {
+        return groupMemberData.first(where: { $0.id == id })
+    }
+
+    func getMemberImage(id: String) -> String {
+        guard let member = getMemberDataBy(id: id) else { return "" }
+        return member.imageUrl ?? ""
+    }
+
+    func getMemberName(id: String, needFullName: Bool = false) -> String {
+        guard let member = getMemberDataBy(id: id) else { return "" }
+        return needFullName ? member.fullName : member.nameWithLastInitial
+    }
+
+    func handleBalanceExpandView(id: String) {
+        if let index = memberBalances.firstIndex(where: { $0.id == id }) {
+            memberBalances[index].isExpanded.toggle()
+        }
+    }
+}
+
+// MARK: - Struct to hold combined expense and user owe amount
+struct GroupMemberBalance {
+    let id: String
+    var isExpanded: Bool = false
+    var totalOwedAmount: Double = 0
+    var balances: [String: Double] = [:]
+}
+
+// MARK: - View States
+extension GroupBalancesViewModel {
+    enum ViewState {
+        case initial
+        case loading
+    }
+}

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -21,6 +21,8 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     @Published var overallOwingAmount = 0.0
     @Published var memberOwingAmount: [String: Double] = [:]
 
+    @Published var showBalancesSheet = false
+
     var group: Groups?
     private let groupId: String
     private var groupUserData: [AppUser] = []
@@ -236,6 +238,10 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
 
     func handleExpenseItemTap(expenseId: String) {
         router.push(.ExpenseDetailView(expenseId: expenseId))
+    }
+
+    func handleBalancesBtnTap() {
+        showBalancesSheet = true
     }
 }
 

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -59,7 +59,7 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] groups in
                 guard let self else { return }
                 self.currentViewState = .initial
-                let sortedGroups = groups.sorted { $0.group.createdAt > $1.group.createdAt }
+                let sortedGroups = groups.sorted { $0.group.name < $1.group.name }
                 self.groupListState = groups.isEmpty ? .noGroup : .hasGroup(groups: sortedGroups)
                 self.usersTotalExpense = totalExpense.value
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new color theme called "SettleUpColor" across the app.
	- Added a new view for displaying group balances in the app, enhancing user interaction with group financial details.
	- Implemented a feature to sort groups by name instead of creation date for improved navigation.
  
- **Enhancements**
	- Modified the default behavior of debt simplification in group settings, now enabling it by default.
	- Improved the visual presentation of various views, including adjustments to padding and font sizes.
  
- **Bug Fixes**
	- Fixed issues related to balance sheet display by adding interactive elements and loading states in the `GroupBalancesView`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->