### PR TITLE
Handle reauthentication

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules: # rule identifiers to exclude from running
   - function_body_length
   - orphaned_doc_comment
   - void_function_in_ternary
+  - non_optional_string_data_conversion
   
 file_length:
   warning: 400

--- a/Data/.swiftlint.yml
+++ b/Data/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules: # rule identifiers to exclude from running
   - function_body_length
   - orphaned_doc_comment
   - void_function_in_ternary
+  - non_optional_string_data_conversion
   
 file_length:
   warning: 400

--- a/Data/Data/Model/AppUser.swift
+++ b/Data/Data/Model/AppUser.swift
@@ -16,7 +16,7 @@ public struct AppUser: Identifiable, Codable {
     public var phoneNumber: String?
     public var imageUrl: String?
     public let loginType: LoginType
-    public var isActive: Bool?
+    public var isActive: Bool
 
     public var fullName: String {
         if let firstName, let lastName {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -961,29 +961,29 @@ PODS:
   - CocoaLumberjack/Core (3.8.5)
   - CocoaLumberjack/Swift (3.8.5):
     - CocoaLumberjack/Core
-  - FirebaseAppCheckInterop (10.25.0)
-  - FirebaseAuth (10.25.0):
+  - FirebaseAppCheckInterop (10.27.0)
+  - FirebaseAuth (10.27.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.25.0)
-  - FirebaseCore (10.25.0):
+  - FirebaseAuthInterop (10.27.0)
+  - FirebaseCore (10.27.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.25.0):
+  - FirebaseCoreExtension (10.27.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.25.0):
+  - FirebaseCoreInternal (10.27.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseFirestore (10.25.0):
+  - FirebaseFirestore (10.27.0):
     - FirebaseCore (~> 10.0)
     - FirebaseCoreExtension (~> 10.0)
-    - FirebaseFirestoreInternal (= 10.25.0)
+    - FirebaseFirestoreInternal (= 10.27.0)
     - FirebaseSharedSwift (~> 10.0)
-  - FirebaseFirestoreInternal (10.25.0):
+  - FirebaseFirestoreInternal (10.27.0):
     - abseil/algorithm (~> 1.20240116.1)
     - abseil/base (~> 1.20240116.1)
     - abseil/container/flat_hash_map (~> 1.20240116.1)
@@ -998,8 +998,8 @@ PODS:
     - gRPC-Core (~> 1.62.0)
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseSharedSwift (10.25.0)
-  - FirebaseStorage (10.25.0):
+  - FirebaseSharedSwift (10.27.0)
+  - FirebaseStorage (10.27.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.25)
     - FirebaseCore (~> 10.0)
@@ -1010,26 +1010,26 @@ PODS:
     - AppAuth (< 2.0, >= 1.7.3)
     - GTMAppAuth (< 5.0, >= 4.1.1)
     - GTMSessionFetcher/Core (~> 3.3)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.2):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.2):
+  - GoogleUtilities/Environment (7.13.3):
     - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.2):
+  - GoogleUtilities/Logger (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.2):
+  - GoogleUtilities/Network (7.13.3):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.2)":
+  - "GoogleUtilities/NSData+zlib (7.13.3)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.2)
-  - GoogleUtilities/Reachability (7.13.2):
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/Reachability (7.13.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - "gRPC-C++ (1.62.5)":
@@ -1124,7 +1124,7 @@ PODS:
   - PromisesObjC (2.4.0)
   - RecaptchaInterop (100.0.0)
   - SSZipArchive (2.5.5)
-  - SwiftLint (0.54.0)
+  - SwiftLint (0.55.1)
   - Swinject (2.8.8)
 
 DEPENDENCIES:
@@ -1174,18 +1174,18 @@ SPEC CHECKSUMS:
   AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
   BoringSSL-GRPC: 1e2348957acdbcad360b80a264a90799984b2ba6
   CocoaLumberjack: 6a459bc897d6d80bd1b8c78482ec7ad05dffc3f0
-  FirebaseAppCheckInterop: 5da5ce93e8797a215e3f677fb0654b74e736c8b8
-  FirebaseAuth: c0f93dcc570c9da2bffb576969d793e95c344fbb
-  FirebaseAuthInterop: 2753ef68cb3cd5aefebe0f58082671cede78350f
-  FirebaseCore: 7ec4d0484817f12c3373955bc87762d96842d483
-  FirebaseCoreExtension: 8a47811d0b155501559ef05d089518152a0a1677
-  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
-  FirebaseFirestore: 977ccc27a3caa5d68279f209c3b0450f85b9dc5f
-  FirebaseFirestoreInternal: 04b8afa77b4e5b84e86ab5ad985193e9573239fa
-  FirebaseSharedSwift: 0274086954b1b2d5fd7e829eccc587044d72a4ba
-  FirebaseStorage: 44f4e25073f6fa0d4d8c09f5bec299ee9e4eb985
+  FirebaseAppCheckInterop: 0dd062c9926a76332ca5711dbed6f1a9ac540b54
+  FirebaseAuth: 77a012b7e08042bf44d0db835ca2e86e6ca7bbd3
+  FirebaseAuthInterop: 0344acef098654eaf59f6add4c93254349bc5de4
+  FirebaseCore: a2b95ae4ce7c83ceecfbbbe3b6f1cddc7415a808
+  FirebaseCoreExtension: 4ec89dd0c6de93d6becde32122d68b7c35f6bf5d
+  FirebaseCoreInternal: 4b297a2d56063dbea2c1d0d04222d44a8d058862
+  FirebaseFirestore: 7169b75e7db8f9796d4130e3c2157ed444f100d4
+  FirebaseFirestoreInternal: 7ba63f170a554ae49392da44f9430e5b7915a7ff
+  FirebaseSharedSwift: a03fe7a59ee646fef71099a887f774fe25d745b8
+  FirebaseStorage: 255526c3d04c49874d7a5e3886964a79f77d6f33
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
-  GoogleUtilities: c56430aef51a1aa57b25da78c3f8397e522c67b7
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   "gRPC-C++": e725ef63c4475d7cdb7e2cf16eb0fde84bd9ee51
   gRPC-Core: eee4be35df218649fe66d721a05a7f27a28f069b
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
@@ -1196,7 +1196,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
+  SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   Swinject: 2943463cdd58b49f114213bf1ce4a09f374828e7
 
 PODFILE CHECKSUM: 10370f2b03f8e9ad8893964fe46dc5645d6026ac

--- a/Splito.xcodeproj/project.pbxproj
+++ b/Splito.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0BF8F99614F85846D78DE106 /* Pods_Splito_SplitoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B9BBF3F71277A6AA5329CB /* Pods_Splito_SplitoUITests.framework */; };
-		217BEC102C00AB9E000CBBB4 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 217BEC0F2C00AB9E000CBBB4 /* Secrets.xcconfig */; };
 		217BEC122C00AD78000CBBB4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 217BEC112C00AD78000CBBB4 /* GoogleService-Info.plist */; };
 		741540F86E36400CE27B1FAD /* Pods_SplitoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 701193A10871F36C3EDB356C /* Pods_SplitoTests.framework */; };
 		D815DFD72BEA26C200C0F862 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D815DFD62BEA26C200C0F862 /* Secrets.xcconfig */; };
@@ -75,7 +74,6 @@
 		D8D14A652BA2DD7300F45FF2 /* UserProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D14A642BA2DD7300F45FF2 /* UserProfileImageView.swift */; };
 		D8D14A672BA2E25100F45FF2 /* UserProfileList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D14A662BA2E25100F45FF2 /* UserProfileList.swift */; };
 		D8D14A692BA3133500F45FF2 /* OnboardRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D14A682BA3133500F45FF2 /* OnboardRouteView.swift */; };
-		D8D42A972B86FBF8009B345D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D8D42A962B86FBF8009B345D /* GoogleService-Info.plist */; };
 		D8D6C3A02B79F8110023CF08 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D6C39F2B79F8110023CF08 /* AppDelegate.swift */; };
 		D8DB68DE2B98AF7600329D51 /* BaseStyle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AC27E12B84C06500CEAAD3 /* BaseStyle.framework */; };
 		D8DB68DF2B98AF7600329D51 /* BaseStyle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D8AC27E12B84C06500CEAAD3 /* BaseStyle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -685,14 +683,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				D896844C2B722D3700D5F721 /* Preview Assets.xcassets in Resources */,
-				217BEC102C00AB9E000CBBB4 /* Secrets.xcconfig in Resources */,
 				D8682E2F2BEE4B3C00BB7273 /* GroupBalance.png in Resources */,
 				D89684492B722D3700D5F721 /* Assets.xcassets in Resources */,
 				D8682E302BEE4B3C00BB7273 /* SplitOption.png in Resources */,
 				D8682E242BEE4B1000BB7273 /* cta.png in Resources */,
 				D8682E252BEE4B1000BB7273 /* banner.png in Resources */,
 				D815DFD72BEA26C200C0F862 /* Secrets.xcconfig in Resources */,
-				D8D42A972B86FBF8009B345D /* GoogleService-Info.plist in Resources */,
 				D889F5B92B7A521F008C6A43 /* SplashView.storyboard in Resources */,
 				D8682E2C2BEE4B3C00BB7273 /* EditExpense.png in Resources */,
 				217BEC122C00AD78000CBBB4 /* GoogleService-Info.plist in Resources */,

--- a/Splito/Localization/Localizable.xcstrings
+++ b/Splito/Localization/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
 
     },
+    " (Admin)" : {
+
+    },
     " %@ " : {
 
     },
@@ -14,9 +17,6 @@
 
     },
     "(%lld people)" : {
-
-    },
-    "(Admin)" : {
 
     },
     "%@" : {
@@ -260,9 +260,6 @@
       "extractionState" : "manual"
     },
     "Select which people owe an equal share." : {
-
-    },
-    "Settings" : {
 
     },
     "Settle up and pay back your friends any time." : {

--- a/Splito/UI/Home/Account/AccountHomeView.swift
+++ b/Splito/UI/Home/Account/AccountHomeView.swift
@@ -29,9 +29,9 @@ struct AccountHomeView: View {
 
                         AccountUserHeaderView(user: viewModel.preference.user, onTap: viewModel.openUserProfileView)
 
-                        AccountFeedbackSectionView(onContactTap: viewModel.onContactUsTap,
-                                                   onRateAppTap: viewModel.onRateAppTap,
-                                                   onShareAppTap: viewModel.onShareAppTap)
+                        AccountStayInTouchSectionView(onContactTap: viewModel.onContactUsTap,
+                                                      onRateAppTap: viewModel.onRateAppTap,
+                                                      onShareAppTap: viewModel.onShareAppTap)
 
                         AccountAboutSectionView(onPrivacyTap: viewModel.handlePrivacyOptionTap, onAcknowledgementsTap: viewModel.handleAcknowledgementsOptionTap)
 
@@ -63,10 +63,9 @@ private struct AccountUserHeaderView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Settings")
-                .font(.subTitle1())
+            Text("Profile")
+                .font(.Header3())
                 .foregroundStyle(primaryText)
-                .padding(.horizontal, 16)
 
             HStack(alignment: .center, spacing: 16) {
                 MemberProfileImageView(imageUrl: user?.imageUrl)
@@ -92,16 +91,12 @@ private struct AccountUserHeaderView: View {
             .onTouchGesture(onTap)
             .background(containerLowColor)
             .cornerRadius(16)
-            .padding(.horizontal, 16)
-
-            Divider()
-                .frame(height: 1)
-                .background(outlineColor)
         }
+        .padding(.horizontal, 16)
     }
 }
 
-private struct AccountFeedbackSectionView: View {
+private struct AccountStayInTouchSectionView: View {
 
     var onContactTap: () -> Void
     var onRateAppTap: () -> Void
@@ -110,18 +105,18 @@ private struct AccountFeedbackSectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Stay In Touch")
-                .font(.subTitle1())
+                .font(.Header3())
                 .foregroundStyle(primaryText)
                 .padding(.vertical, 10)
 
-            VStack(spacing: 12) {
+            VStack(spacing: 14) {
                 AccountItemCellView(optionText: "Contact us", onClick: onContactTap)
 
                 AccountItemCellView(optionText: "Rate Splito", onClick: onRateAppTap)
 
                 AccountItemCellView(optionText: "Share app", onClick: onShareAppTap)
             }
-            .padding(.vertical, 12)
+            .padding(.vertical, 16)
             .background(containerLowColor)
             .cornerRadius(16)
         }
@@ -137,16 +132,16 @@ private struct AccountAboutSectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("About")
-                .font(.subTitle1())
+                .font(.Header3())
                 .foregroundStyle(primaryText)
                 .padding(.vertical, 10)
 
-            VStack(spacing: 12) {
+            VStack(spacing: 14) {
                 AccountItemCellView(optionText: "Privacy", onClick: onPrivacyTap)
 
                 AccountItemCellView(optionText: "Acknowledgements", onClick: onAcknowledgementsTap)
             }
-            .padding(.vertical, 12)
+            .padding(.vertical, 16)
             .background(containerLowColor)
             .cornerRadius(16)
         }

--- a/Splito/UI/Home/Account/AccountRouteView.swift
+++ b/Splito/UI/Home/Account/AccountRouteView.swift
@@ -19,7 +19,7 @@ struct AccountRouteView: View {
             case .AccountHomeView:
                 AccountHomeView(viewModel: AccountHomeViewModel(router: appRoute))
             case .ProfileView:
-                UserProfileView(viewModel: UserProfileViewModel(router: appRoute, isOpenedFromOnboard: false, onDismiss: nil))
+                UserProfileView(viewModel: UserProfileViewModel(router: appRoute, isOpenFromOnboard: false, onDismiss: nil))
             default:
                 EmptyRouteView(routeName: self)
             }

--- a/Splito/UI/Home/Account/User Profile/UserProfileView.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileView.swift
@@ -44,8 +44,9 @@ struct UserProfileView: View {
 
                     VSpacer(8)
 
-                    if viewModel.isOpenedFromOnboard {
-                        PrimaryButton(text: "Save", isEnabled: viewModel.email.isValidEmail && viewModel.firstName.trimming(spaces: .leadingAndTrailing).count >= 3, showLoader: viewModel.isSaveInProgress, onClick: viewModel.updateUserProfile)
+                    if viewModel.isOpenFromOnboard {
+                        PrimaryButton(text: "Save", isEnabled: viewModel.email.isValidEmail && viewModel.firstName.trimming(spaces: .leadingAndTrailing).count >= 3,
+                                      showLoader: viewModel.isSaveInProgress, onClick: viewModel.updateUserProfile)
                     }
 
                     Button(action: viewModel.showDeleteAccountConfirmation) {
@@ -65,7 +66,7 @@ struct UserProfileView: View {
                         .clipShape(Capsule())
                     }
                     .buttonStyle(.scale)
-                    .hidden(viewModel.isOpenedFromOnboard)
+                    .hidden(viewModel.isOpenFromOnboard)
 
                     VSpacer(40)
                 }
@@ -124,7 +125,7 @@ private struct UserDetailList: View {
     }
 
     var isEmailDisable: Bool {
-        (userLoginType == .Google || userLoginType == .Apple) && !email.isEmpty
+        userLoginType == .Google
     }
 
     var body: some View {
@@ -171,7 +172,8 @@ private struct UserDetailCell: View {
 
             VSpacer(8)
 
-            UserProfileDataEditableTextField(titleText: $titleText, isDisabled: isDisabled, placeholder: placeholder, fieldType: fieldType, keyboardType: keyboardType, focused: focused, autoCapitalizationType: autoCapitalizationType)
+            UserProfileDataEditableTextField(titleText: $titleText, isDisabled: isDisabled, placeholder: placeholder, fieldType: fieldType,
+                                             keyboardType: keyboardType, focused: focused, autoCapitalizationType: autoCapitalizationType)
 
             VSpacer(8)
 

--- a/Splito/UI/Home/Account/User Profile/UserProfileView.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileView.swift
@@ -256,5 +256,5 @@ private struct UserProfileDataEditableTextField: View {
 }
 
 #Preview {
-    UserProfileView(viewModel: UserProfileViewModel(router: .init(root: .ProfileView), isOpenedFromOnboard: true, onDismiss: nil))
+    UserProfileView(viewModel: UserProfileViewModel(router: .init(root: .ProfileView), isOpenFromOnboard: true, onDismiss: nil))
 }

--- a/Splito/UI/Home/Account/User Profile/UserProfileView.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileView.swift
@@ -39,13 +39,17 @@ struct UserProfileView: View {
                     }
 
                     UserDetailList(firstName: $viewModel.firstName, lastName: $viewModel.lastName,
-                                   email: $viewModel.email, phone: $viewModel.phone,
+                                   email: $viewModel.email, phone: $viewModel.phoneNumber,
                                    userLoginType: $viewModel.userLoginType)
 
                     VSpacer(8)
 
                     if viewModel.isOpenFromOnboard {
-                        PrimaryButton(text: "Save", isEnabled: viewModel.email.isValidEmail && viewModel.firstName.trimming(spaces: .leadingAndTrailing).count >= 3,
+                        let isEnable = (viewModel.email.isValidEmail &&
+                                        viewModel.firstName.trimming(spaces: .leadingAndTrailing).count >= 3) ||
+                                       !(viewModel.userLoginType == .Google)
+
+                        PrimaryButton(text: "Save", isEnabled: isEnable,
                                       showLoader: viewModel.isSaveInProgress, onClick: viewModel.updateUserProfile)
                     }
 
@@ -102,6 +106,11 @@ struct UserProfileView: View {
         .sheet(isPresented: $viewModel.showImagePicker) {
             ImagePickerView(cropOption: .square, sourceType: !viewModel.sourceTypeIsCamera ? .photoLibrary : .camera,
                             image: $viewModel.profileImage, isPresented: $viewModel.showImagePicker)
+        }
+        .sheet(isPresented: $viewModel.showOTPView) {
+            VerifyOtpView(viewModel: VerifyOtpViewModel(phoneNumber: viewModel.phoneNumber, verificationId: viewModel.verificationId, onLoginSuccess: { otp in
+                viewModel.otpPublisher.send(otp)
+            }))
         }
     }
 }

--- a/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
@@ -148,19 +148,18 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
         alert = .init(title: "Delete your account",
                       message: "Are you ABSOLUTELY sure you want to close your splito account? You will no longer be able to log into your account or access your account history from your splito app.",
                       positiveBtnTitle: "Delete",
-                      positiveBtnAction: { self.handleDeleteAccountAction() },
+                      positiveBtnAction: { self.deleteUser() },
                       negativeBtnTitle: "Cancel",
                       negativeBtnAction: { self.showAlert = false }, isPositiveBtnDestructive: true)
         showAlert = true
     }
 
-    func handleDeleteAccountAction() {
+    private func deleteUser() {
         guard let user = preference.user else {
             LogD("UserProfileViewModel :: user not exists.")
             return
         }
 
-        isDeleteInProgress = true
         userRepository.deleteUser(id: user.id)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
@@ -243,24 +242,6 @@ extension UserProfileViewModel {
         case .Phone:
             handlePhoneLogin(completion: completion)
         }
-    }
-
-    private func deleteUser() {
-        guard let user = preference.user else { return }
-        userRepository.deleteUser(id: user.id)
-            .sink { [weak self] completion in
-                if case .failure(let error) = completion {
-                    self?.isDeleteInProgress = false
-                    self?.showAlertFor(error)
-                }
-            } receiveValue: { [weak self] _ in
-                guard let self else { return }
-                self.isDeleteInProgress = false
-                self.preference.clearPreferenceSession()
-                self.preference.isOnboardShown = false
-                self.goToOnboardScreen()
-                LogD("UserProfileViewModel :: user deleted.")
-            }.store(in: &cancelable)
     }
 
     private func handleAppleLogin(completion: @escaping (AuthCredential?) -> Void) {

--- a/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
@@ -43,17 +43,17 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
 
     var verificationId = ""
     private var currentNonce: String = ""
-    private var appleSignInDelegates: SignInWithAppleDelegates! = nil
+    private lazy var appleSignInDelegates: SignInWithAppleDelegates! = nil
 
     private let router: Router<AppRoute>?
     private var onDismiss: (() -> Void)?
 
     var otpPublisher = PassthroughSubject<String, Never>()
 
-    init(router: Router<AppRoute>?, isOpenedFromOnboard: Bool, onDismiss: (() -> Void)?) {
+    init(router: Router<AppRoute>?, isOpenFromOnboard: Bool, onDismiss: (() -> Void)?) {
         self.router = router
         self.onDismiss = onDismiss
-        self.isOpenFromOnboard = isOpenedFromOnboard
+        self.isOpenFromOnboard = isOpenFromOnboard
         super.init()
         fetchUserDetail()
     }
@@ -156,7 +156,7 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
 
     private func deleteUser() {
         guard let user = preference.user else {
-            LogD("UserProfileViewModel :: user not exists.")
+            LogD("UserProfileViewModel :: User does not exist.")
             return
         }
 

--- a/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
@@ -7,11 +7,17 @@
 
 import SwiftUI
 import Data
+import BaseStyle
 import AVFoundation
+import FirebaseAuth
+import FirebaseCore
+import GoogleSignIn
+import AuthenticationServices
 
 public class UserProfileViewModel: BaseViewModel, ObservableObject {
 
     private let NAME_CHARACTER_MIN_LIMIT = 3
+    private let REQUIRE_AGAIN_LOGIN_TEXT = "requires recent authentication"
 
     @Inject private var preference: SplitoPreference
     @Inject private var userRepository: UserRepository
@@ -29,9 +35,12 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
     @Published var showImagePicker = false
     @Published var showImagePickerOption = false
 
-    @Published var isSaveInProgress: Bool = false
-    @Published var isDeleteInProgress: Bool = false
-    @Published var isOpenedFromOnboard: Bool
+    @Published var isOpenFromOnboard: Bool
+    @Published var isSaveInProgress = false
+    @Published var isDeleteInProgress = false
+
+    private var currentNonce: String = ""
+    private var appleSignInDelegates: SignInWithAppleDelegates! = nil
 
     private let router: Router<AppRoute>?
     private var onDismiss: (() -> Void)?
@@ -39,7 +48,7 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
     init(router: Router<AppRoute>?, isOpenedFromOnboard: Bool, onDismiss: (() -> Void)?) {
         self.router = router
         self.onDismiss = onDismiss
-        self.isOpenedFromOnboard = isOpenedFromOnboard
+        self.isOpenFromOnboard = isOpenedFromOnboard
         super.init()
         fetchUserDetail()
     }
@@ -99,91 +108,188 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
     }
 
     func updateUserProfile() {
-        if let user = preference.user {
-            var newUser = user
-            newUser.firstName = firstName.capitalized
-            newUser.lastName = lastName.capitalized
-            newUser.emailId = email
-            newUser.phoneNumber = phone
+        guard let user = preference.user else { return }
 
-            let resizedImage = profileImage?.aspectFittedToHeight(200)
-            let imageData = resizedImage?.jpegData(compressionQuality: 0.2)
+        var newUser = user
+        newUser.firstName = firstName.capitalized
+        newUser.lastName = lastName.capitalized
+        newUser.emailId = email
+        newUser.phoneNumber = phone
 
-            isSaveInProgress = true
-            userRepository.updateUserWithImage(imageData: imageData, newImageUrl: profileImageUrl, user: newUser)
-                .sink { [weak self] completion in
-                    if case .failure(let error) = completion {
-                        self?.isSaveInProgress = false
-                        self?.showAlertFor(error)
-                    }
-                } receiveValue: { [weak self] user in
-                    guard let self else { return }
-                    self.isSaveInProgress = false
-                    self.preference.user = user
+        let resizedImage = profileImage?.aspectFittedToHeight(200)
+        let imageData = resizedImage?.jpegData(compressionQuality: 0.2)
 
-                    if self.isOpenedFromOnboard {
-                        self.onDismiss?()
-                    } else {
-                        self.router?.pop()
-                    }
-                }.store(in: &cancelable)
-        }
+        isSaveInProgress = true
+        userRepository.updateUserWithImage(imageData: imageData, newImageUrl: profileImageUrl, user: newUser)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.isSaveInProgress = false
+                    self?.showAlertFor(error)
+                }
+            } receiveValue: { [weak self] user in
+                guard let self else { return }
+                self.isSaveInProgress = false
+                self.preference.user = user
+
+                if self.isOpenFromOnboard {
+                    self.onDismiss?()
+                } else {
+                    self.router?.pop()
+                }
+            }.store(in: &cancelable)
     }
 
     func showDeleteAccountConfirmation() {
-        alert = .init(title: "Delete your account", message: "Are you ABSOLUTELY sure you want to close your splito account? You will no longer be able to log into your account or access your account history from your splito app",
+        alert = .init(title: "Delete your account",
+                      message: "Are you ABSOLUTELY sure you want to close your splito account? You will no longer be able to log into your account or access your account history from your splito app.",
                       positiveBtnTitle: "Delete",
-                      positiveBtnAction: { self.deactivateUser() },
+                      positiveBtnAction: { self.handleDeleteAccountAction() },
                       negativeBtnTitle: "Cancel",
                       negativeBtnAction: { self.showAlert = false }, isPositiveBtnDestructive: true)
         showAlert = true
     }
 
-    func handleDeleteAction() {
-        if let user = preference.user {
-            isDeleteInProgress = true
-            userRepository.deleteUser(id: user.id)
-                .sink { [weak self] completion in
-                    if case .failure(let error) = completion {
-                        self?.isDeleteInProgress = false
-                        self?.showAlertFor(error)
-                    }
-                } receiveValue: { [weak self] _ in
+    func handleDeleteAccountAction() {
+        guard let user = preference.user else {
+            LogD("UserProfileViewModel :: user not exists.")
+            return
+        }
+
+        isDeleteInProgress = true
+        userRepository.deleteUser(id: user.id)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
                     guard let self else { return }
-                    self.isDeleteInProgress = false
-                    self.preference.clearPreferenceSession()
-                    self.preference.isOnboardShown = false
-                    self.goToOnboardScreen()
-                    LogD("UserProfileViewModel :: user deleted.")
-                }.store(in: &cancelable)
-        } else {
-            LogD("UserProfileViewModel :: user not exists.")
-        }
-    }
-
-    func deactivateUser() {
-        if let user = preference.user {
-            let newUser = AppUser(id: user.id, firstName: user.firstName, lastName: user.lastName, emailId: user.emailId, phoneNumber: user.phoneNumber, profileImageUrl: user.imageUrl, loginType: user.loginType, isActive: false)
-
-            isDeleteInProgress = true
-            userRepository.updateUser(user: newUser)
-                .sink { [weak self] completion in
-                    if case .failure(let error) = completion {
-                        self?.isDeleteInProgress = false
-                        self?.showAlertFor(error)
+                    if error.descriptionText.contains(self.REQUIRE_AGAIN_LOGIN_TEXT) {
+						self.alert = .init(title: "", message: error.descriptionText,
+						positiveBtnTitle: "Reauthenticate", positiveBtnAction: {
+							self.reAuthenticateUser()
+						}, negativeBtnTitle: "Cancel", negativeBtnAction: {
+							self.showAlert = false
+							self.isDeleteInProgress = false
+						})
+                        self.showAlert = true
                     }
-                } receiveValue: { [weak self] _ in
-                    self?.isDeleteInProgress = false
-                    LogD("UserProfileViewModel :: user deactived successfully.")
-                    self?.handleDeleteAction()
-                }.store(in: &cancelable)
-        } else {
-            LogD("UserProfileViewModel :: user not exists.")
-        }
+                }
+            } receiveValue: { [weak self] _ in
+                guard let self else { return }
+                self.isDeleteInProgress = false
+                self.preference.isOnboardShown = false
+                self.preference.clearPreferenceSession()
+                self.goToOnboardScreen()
+				LogD("UserProfileViewModel :: user deleted.")
+            }.store(in: &cancelable)
     }
+
+	func deleteUser() {
+		guard let user = preference.user else { return }
+		userRepository.deleteUser(id: user.id)
+			.sink { [weak self] completion in
+				if case .failure(let error) = completion {
+					self?.isDeleteInProgress = false
+					self?.showAlertFor(error)
+				}
+			} receiveValue: { [weak self] _ in
+				guard let self else { return }
+				self.isDeleteInProgress = false
+				self.preference.clearPreferenceSession()
+				self.preference.isOnboardShown = false
+				self.goToOnboardScreen()
+				LogD("UserProfileViewModel :: user deleted.")
+			}.store(in: &cancelable)
+	}
 
     private func goToOnboardScreen() {
         router?.popToRoot()
+    }
+}
+
+// MARK: - Reauthentication Actions
+
+extension UserProfileViewModel {
+    private func reAuthenticateUser() {
+        guard let user = FirebaseProvider.auth.currentUser else {
+            LogE("UserProfileViewModel: User not found for delete.")
+            return
+        }
+
+        user.reload { [weak self] error in
+            if let error {
+                self?.isDeleteInProgress = false
+                LogE("UserProfileViewModel: Error reloading user: \(error.localizedDescription)")
+            } else {
+                self?.promptForReAuthentication(user)
+            }
+        }
+    }
+
+    func promptForReAuthentication(_ user: User) {
+        getAuthCredential(user) { [weak self] credential in
+            guard let credential else {
+                self?.isDeleteInProgress = false
+                LogE("UserProfileViewModel: Credential are - \(String(describing: credential))")
+                return
+            }
+
+            user.reauthenticate(with: credential) { _, error in
+                if let error {
+                    self?.isDeleteInProgress = false
+                    LogE("UserProfileViewModel: Error re-authenticating user: \(error.localizedDescription)")
+                } else {
+                    self?.deleteUser()
+                }
+            }
+        }
+    }
+
+    private func getAuthCredential(_ authUser: User, completion: @escaping (AuthCredential?) -> Void) {
+        guard let appUser = preference.user else { return }
+
+        switch appUser.loginType {
+        case .Apple:
+            currentNonce = NonceGenerator.randomNonceString()
+            let request = ASAuthorizationAppleIDProvider().createRequest()
+            request.requestedScopes = [.fullName, .email]
+            request.nonce = NonceGenerator.sha256(currentNonce)
+
+            isDeleteInProgress = false
+
+            appleSignInDelegates = SignInWithAppleDelegates { (token, _, _, _)  in
+                self.isDeleteInProgress = true
+                let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: token, rawNonce: self.currentNonce)
+                completion(credential)
+            }
+
+            let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+            authorizationController.delegate = appleSignInDelegates
+            authorizationController.performRequests()
+
+        case .Google:
+            let clientID = FirebaseApp.app()?.options.clientID ?? ""
+
+            let config = GIDConfiguration(clientID: clientID)
+            GIDSignIn.sharedInstance.configuration = config
+
+            guard let controller = TopViewController.shared.topViewController() else {
+                LogE("UserProfileViewModel :: Top Controller not found.")
+                return
+            }
+
+            GIDSignIn.sharedInstance.signIn(withPresenting: controller) { result, error in
+                guard error == nil else {
+                    self.isDeleteInProgress = false
+                    LogE("UserProfileViewModel :: Google Login Error: \(String(describing: error))")
+                    return
+                }
+
+                guard let user = result?.user, let idToken = user.idToken?.tokenString else { return }
+                let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: user.accessToken.tokenString)
+                completion(credential)
+            }
+
+        case .Phone:
+            completion(nil)
+        }
     }
 }
 

--- a/Splito/UI/Home/Groups/Group/Group Setting/GroupSettingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Setting/GroupSettingView.swift
@@ -236,7 +236,7 @@ private struct GroupMemberCellView: View {
                         .foregroundStyle(primaryText)
 
                     if isAdmin {
-                        Text("(Admin)")
+                        Text(" (Admin)")
                             .font(.caption)
                             .foregroundColor(secondaryText)
                     }

--- a/Splito/UI/Home/HomeRouteView.swift
+++ b/Splito/UI/Home/HomeRouteView.swift
@@ -49,7 +49,7 @@ struct HomeRouteView: View {
         }
         .onAppear {
             if preference.isVerifiedUser {
-                if preference.user == nil || (preference.user?.firstName == nil) {
+                if preference.user == nil || (preference.user?.firstName == nil) || (preference.user?.firstName == "") {
                     openProfileView = true
                 }
             }

--- a/Splito/UI/Home/HomeRouteView.swift
+++ b/Splito/UI/Home/HomeRouteView.swift
@@ -41,7 +41,7 @@ struct HomeRouteView: View {
                 ExpenseRouteView()
             }
             .sheet(isPresented: $openProfileView) {
-                UserProfileView(viewModel: UserProfileViewModel(router: nil, isOpenedFromOnboard: true, onDismiss: {
+                UserProfileView(viewModel: UserProfileViewModel(router: nil, isOpenFromOnboard: true, onDismiss: {
                     openProfileView = false
                 }))
                 .interactiveDismissDisabled()

--- a/Splito/UI/Login/LoginViewModel.swift
+++ b/Splito/UI/Login/LoginViewModel.swift
@@ -22,8 +22,7 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
     @Inject private var userRepository: UserRepository
 
     private var currentNonce: String = ""
-
-    var appleSignInDelegates: SignInWithAppleDelegates! = nil
+    private var appleSignInDelegates: SignInWithAppleDelegates! = nil
 
     private let router: Router<AppRoute>
 
@@ -94,7 +93,7 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
                 } else if let result {
                     self.showGoogleLoading = false
                     self.showAppleLoading = false
-                    let user = AppUser(id: result.user.uid, firstName: userData.0, lastName: userData.1, emailId: userData.2, phoneNumber: nil, loginType: loginType, isActive: true)
+                    let user = AppUser(id: result.user.uid, firstName: userData.0, lastName: userData.1, emailId: userData.2, phoneNumber: nil, loginType: loginType)
                     self.storeUser(user: user)
                     LogD("LoginViewModel :: Logged in User: \(result.user)")
                 } else {
@@ -108,15 +107,13 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
         userRepository.storeUser(user: user)
             .sink { [weak self] completion in
                 guard let self else { return }
-                switch completion {
-                case .failure(let error):
-                    self.alert = .init(message: error.localizedDescription)
-                    self.showAlert = true
-                case .finished:
-                    self.preference.user = user
-                }
+				if case .failure(let error) = completion {
+					self.alert = .init(message: error.localizedDescription)
+					self.showAlert = true
+				}
             } receiveValue: { [weak self] _ in
                 guard let self else { return }
+				self.preference.user = user
                 self.onLoginSuccess()
             }.store(in: &cancelable)
     }

--- a/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpView.swift
+++ b/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpView.swift
@@ -41,12 +41,14 @@ public struct VerifyOtpView: View {
                             .font(.subTitle2())
                             .foregroundStyle(primaryText)
 
-                        Button(action: viewModel.editButtonAction, label: {
-                            Image(.editPencil)
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 24, height: 24, alignment: .center)
-                        })
+                        if viewModel.isFromPhoneLogin {
+                            Button(action: viewModel.editButtonAction, label: {
+                                Image(.editPencil)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 24, height: 24, alignment: .center)
+                            })
+                        }
                     }
                 }
                 .padding(.horizontal, 40)

--- a/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpViewModel.swift
+++ b/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpViewModel.swift
@@ -43,7 +43,7 @@ public class VerifyOtpViewModel: BaseViewModel, ObservableObject {
             self?.showLoader = false
             if let result {
                 self?.resendTimer?.invalidate()
-                let user = AppUser(id: result.user.uid, firstName: nil, lastName: nil, emailId: nil, phoneNumber: result.user.phoneNumber, loginType: .Phone, isActive: true)
+                let user = AppUser(id: result.user.uid, firstName: nil, lastName: nil, emailId: nil, phoneNumber: result.user.phoneNumber, loginType: .Phone)
                 self?.storeUser(user: user)
             } else {
                 self?.onLoginError()

--- a/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpViewModel.swift
+++ b/Splito/UI/Login/PhoneLogin/VerifyOtp/VerifyOtpViewModel.swift
@@ -23,15 +23,19 @@ public class VerifyOtpViewModel: BaseViewModel, ObservableObject {
     var resendTimer: Timer?
     var phoneNumber: String
     var verificationId: String
+    var isFromPhoneLogin = false
 
-    private let router: Router<AppRoute>
+    private let router: Router<AppRoute>?
+    private var onLoginSuccess: ((String) -> Void)?
 
-    init(router: Router<AppRoute>, phoneNumber: String, verificationId: String) {
+    init(router: Router<AppRoute>? = nil, phoneNumber: String, verificationId: String, onLoginSuccess: ((String) -> Void)? = nil) {
         self.router = router
         self.phoneNumber = phoneNumber
         self.verificationId = verificationId
+        self.onLoginSuccess = onLoginSuccess
         super.init()
         runTimer()
+        isFromPhoneLogin = onLoginSuccess == nil
     }
 
     func verifyOTP() {
@@ -108,15 +112,19 @@ extension VerifyOtpViewModel {
             } receiveValue: { [weak self] user in
                 guard let self else { return }
                 self.preference.user = user
-                self.onLoginSuccess()
+                self.onVerificationSuccess()
             }.store(in: &cancelable)
     }
 
     func editButtonAction() {
-        router.pop()
+        router?.pop()
     }
 
-    private func onLoginSuccess() {
-        router.popToRoot()
+    private func onVerificationSuccess() {
+        if onLoginSuccess == nil {
+            router?.popToRoot()
+        } else {
+            onLoginSuccess?(otp)
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new sheet presentation for `VerifyOtpView` based on `showOTPView`.
  - Introduced new functionality for handling account deletion and reauthentication.

- **Bug Fixes**
  - Corrected the visibility condition for certain UI elements in `UserProfileView`.
  - Adjusted the logic for enabling the "Save" button based on email validation and first name length.

- **Improvements**
  - Updated text "Settings" to "Profile" with a different font style.
  - Adjusted padding and spacing in various sections for visual improvements.

- **Refactor**
  - Renamed `isOpenedFromOnboard` to `isOpenFromOnboard` across multiple files.
  - Changed `isActive` variable in `AppUser` from optional to non-optional.
  - Renamed `AccountFeedbackSectionView` to `AccountStayInTouchSectionView`.

- **Chores**
  - Removed references to `Secrets.xcconfig` and `GoogleService-Info.plist`.
  - Added `non_optional_string_data_conversion` rule to the list of disabled rules in `.swiftlint.yml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->