### PR TITLE
Implement who is paying & who is getting paid screen

### DIFF
--- a/Data/Data/Router/AppRoute.swift
+++ b/Data/Data/Router/AppRoute.swift
@@ -30,6 +30,10 @@ public enum AppRoute: Hashable {
     case InviteMemberView(groupId: String)
     case JoinMemberView
     case GroupSettingView(groupId: String)
+    case GroupSettleUpView(groupId: String?)
+    case GroupWhoIsPayingView(groupId: String)
+    case GroupWhoGettingPaidView(groupId: String, selectedMemberId: String)
+    case GroupPaymentView(groupId: String)
 
     // MARK: - Expense Button
     case AddExpenseView(expenseId: String?)
@@ -76,6 +80,14 @@ public enum AppRoute: Hashable {
             "joinMemberView"
         case .GroupSettingView:
             "groupSettingView"
+        case .GroupSettleUpView:
+            "groupSettleUpView"
+        case .GroupWhoIsPayingView:
+            "groupWhoIsPayingView"
+        case .GroupWhoGettingPaidView:
+            "groupWhoGettingPaidView"
+        case .GroupPaymentView:
+            "groupPaymentView"
 
         case .AddExpenseView:
             "addExpenseView"

--- a/Data/Data/Router/AppRoute.swift
+++ b/Data/Data/Router/AppRoute.swift
@@ -30,7 +30,7 @@ public enum AppRoute: Hashable {
     case InviteMemberView(groupId: String)
     case JoinMemberView
     case GroupSettingView(groupId: String)
-    case GroupSettleUpView(groupId: String?)
+    case GroupSettleUpView(groupId: String)
     case GroupWhoIsPayingView(groupId: String)
     case GroupWhoGettingPaidView(groupId: String, selectedMemberId: String)
     case GroupPaymentView(groupId: String)

--- a/Splito.xcodeproj/project.pbxproj
+++ b/Splito.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0BF8F99614F85846D78DE106 /* Pods_Splito_SplitoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B9BBF3F71277A6AA5329CB /* Pods_Splito_SplitoUITests.framework */; };
+		213BA0602C0F465000116130 /* GroupSettleUpRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213BA05F2C0F465000116130 /* GroupSettleUpRouteView.swift */; };
 		217BEC122C00AD78000CBBB4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 217BEC112C00AD78000CBBB4 /* GoogleService-Info.plist */; };
 		741540F86E36400CE27B1FAD /* Pods_SplitoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 701193A10871F36C3EDB356C /* Pods_SplitoTests.framework */; };
 		D815DFD72BEA26C200C0F862 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D815DFD62BEA26C200C0F862 /* Secrets.xcconfig */; };
@@ -130,6 +131,7 @@
 
 /* Begin PBXFileReference section */
 		038CCD15E82A4E16A4AD213C /* Pods-Splito-SplitoUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Splito-SplitoUITests.release.xcconfig"; path = "Target Support Files/Pods-Splito-SplitoUITests/Pods-Splito-SplitoUITests.release.xcconfig"; sourceTree = "<group>"; };
+		213BA05F2C0F465000116130 /* GroupSettleUpRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSettleUpRouteView.swift; sourceTree = "<group>"; };
 		217BEC0F2C00AB9E000CBBB4 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		217BEC112C00AD78000CBBB4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		43FFDB1561C565EE6E3DC86A /* Pods_Splito.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Splito.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -340,6 +342,7 @@
 		D83344562C0DD03B00CD9F05 /* Settle up */ = {
 			isa = PBXGroup;
 			children = (
+				213BA05F2C0F465000116130 /* GroupSettleUpRouteView.swift */,
 				D83344572C0DD06F00CD9F05 /* GroupSettleUpView.swift */,
 				D83344592C0DD08400CD9F05 /* GroupSettleUpViewModel.swift */,
 				D833446F2C0F2D6C00CD9F05 /* Payment */,
@@ -960,6 +963,7 @@
 				D83344652C0F2CEB00CD9F05 /* GroupWhoIsPayingView.swift in Sources */,
 				D8302DA02B9F282F005ACA13 /* InviteMemberView.swift in Sources */,
 				D89684452B722D3400D5F721 /* SplitoApp.swift in Sources */,
+				213BA0602C0F465000116130 /* GroupSettleUpRouteView.swift in Sources */,
 				D8AC26F72B84B12800CEAAD3 /* LoginView.swift in Sources */,
 				D8CD952E2BD65F4500407B47 /* ExpenseSplitOptionsViewModel.swift in Sources */,
 				D85E86E32BAB06D9002EDF76 /* AddExpenseViewModel.swift in Sources */,

--- a/Splito/Localization/Localizable.xcstrings
+++ b/Splito/Localization/Localizable.xcstrings
@@ -193,7 +193,7 @@
     "Groups make it easy to split apartment bills, share travel expenses, and more." : {
 
     },
-    "Hello, World!" : {
+    "Hello World" : {
 
     },
     "Invite Code" : {
@@ -228,6 +228,9 @@
     },
     "no balance" : {
 
+    },
+    "No email address" : {
+      "extractionState" : "manual"
     },
     "no expense" : {
 
@@ -266,6 +269,9 @@
 
     },
     "Profile" : {
+
+    },
+    "Record a payment" : {
 
     },
     "Remove" : {
@@ -377,6 +383,12 @@
 
     },
     "Which balance do you want to settle?" : {
+
+    },
+    "Who is getting paid?" : {
+
+    },
+    "Who is paying?" : {
 
     },
     "You" : {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
@@ -1,0 +1,33 @@
+//
+//  GroupSettleUpRouteView.swift
+//  Splito
+//
+//  Created by Nirali Sonani on 04/06/24.
+//
+
+import Data
+import SwiftUI
+import BaseStyle
+
+struct GroupSettleUpRouteView: View {
+
+    @StateObject var appRoute: Router<AppRoute>
+
+    var body: some View {
+        RouterView(router: appRoute) { route in
+            switch route {
+            case .GroupSettleUpView(let groupId):
+                GroupSettleUpView(viewModel: GroupSettleUpViewModel(router: appRoute, groupId: groupId))
+            case .GroupWhoIsPayingView(let groupId):
+                GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(router: appRoute, groupId: groupId))
+            case .GroupWhoGettingPaidView(let groupId, let selectedMemberId):
+                GroupWhoGettingPaidView(viewModel: GroupWhoGettingPaidViewModel(router: appRoute, groupId: groupId, selectedMemberId: selectedMemberId))
+            case .GroupPaymentView(let groupId):
+                GroupPaymentView(viewModel: GroupPaymentViewModel(router: appRoute, groupId: groupId))
+
+            default:
+                EmptyRouteView(routeName: self)
+            }
+        }
+    }
+}

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
@@ -2,7 +2,7 @@
 //  GroupSettleUpRouteView.swift
 //  Splito
 //
-//  Created by Nirali Sonani on 04/06/24.
+//  Created by Amisha Italiya on 04/06/24.
 //
 
 import Data

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
@@ -98,6 +98,9 @@ private struct GroupMembersListView: View {
             ForEach(sortedMembers, id: \.key) { memberId, owingAmount in
                 if let member = viewModel.getMemberDataBy(id: memberId) {
                     GroupMemberCellView(member: member, amount: owingAmount)
+                        .onTouchGesture {
+                            viewModel.onMemberTap(member)
+                        }
 
                     Divider()
                         .frame(height: 1)

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
@@ -157,5 +157,5 @@ private struct GroupMemberCellView: View {
 }
 
 #Preview {
-    GroupSettleUpView(viewModel: GroupSettleUpViewModel(groupId: ""))
+    GroupSettleUpView(viewModel: GroupSettleUpViewModel(router: nil, groupId: ""))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -22,11 +22,11 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     @Published private var expenses: [Expense] = []
     @Published var memberOwingAmount: [String: Double] = [:]
 
-    private let groupId: String?
+    private let groupId: String
     private var groupMemberData: [AppUser] = []
     private let router: Router<AppRoute>?
 
-    init(router: Router<AppRoute>? = nil, groupId: String?) {
+    init(router: Router<AppRoute>? = nil, groupId: String) {
         self.router = router
         self.groupId = groupId
         super.init()
@@ -35,8 +35,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
 
     // MARK: - Data Loading
     func fetchGroupDetails() {
-        guard let groupId else { return }
-
         groupRepository.fetchGroupBy(id: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
@@ -50,7 +48,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     private func fetchGroupMembers() {
-        guard let user = preference.user, let groupId = groupId else { return }
+        guard let user = preference.user else { return }
 
         groupRepository.fetchMembersBy(groupId: groupId)
             .sink { [weak self] completion in
@@ -66,8 +64,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     private func fetchExpenses() {
-        guard let groupId else { return }
-
         expenseRepository.fetchExpensesBy(groupId: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
@@ -182,7 +178,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     func handleMoreButtonTap() {
-        guard let groupId else { return }
         router?.push(.GroupWhoIsPayingView(groupId: groupId))
     }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -181,6 +181,10 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
         router?.push(.GroupWhoIsPayingView(groupId: groupId))
     }
 
+    func onMemberTap(_ member: AppUser) {
+        router?.push(.GroupPaymentView(groupId: groupId))
+    }
+
     // MARK: - Error Handling
     private func handleServiceError(_ error: ServiceError) {
         viewState = .initial

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -22,10 +22,12 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     @Published private var expenses: [Expense] = []
     @Published var memberOwingAmount: [String: Double] = [:]
 
-    private let groupId: String
+    private let groupId: String?
     private var groupMemberData: [AppUser] = []
+    private let router: Router<AppRoute>?
 
-    init(groupId: String) {
+    init(router: Router<AppRoute>? = nil, groupId: String?) {
+        self.router = router
         self.groupId = groupId
         super.init()
         fetchGroupDetails()
@@ -33,6 +35,8 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
 
     // MARK: - Data Loading
     func fetchGroupDetails() {
+        guard let groupId else { return }
+
         groupRepository.fetchGroupBy(id: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
@@ -46,7 +50,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     private func fetchGroupMembers() {
-        guard let user = preference.user else { return }
+        guard let user = preference.user, let groupId = groupId else { return }
 
         groupRepository.fetchMembersBy(groupId: groupId)
             .sink { [weak self] completion in
@@ -62,6 +66,8 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     private func fetchExpenses() {
+        guard let groupId else { return }
+
         expenseRepository.fetchExpensesBy(groupId: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
@@ -176,7 +182,8 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
     }
 
     func handleMoreButtonTap() {
-
+        guard let groupId else { return }
+        router?.push(.GroupWhoIsPayingView(groupId: groupId))
     }
 
     // MARK: - Error Handling

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import BaseStyle
 
 struct GroupPaymentView: View {
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
@@ -6,13 +6,34 @@
 //
 
 import SwiftUI
+import BaseStyle
 
 struct GroupPaymentView: View {
+
+    @StateObject var viewModel: GroupPaymentViewModel
+
     var body: some View {
-        Text("Hello, World!")
+        VStack(alignment: .leading, spacing: 0) {
+            if case .loading = viewModel.viewState {
+                LoaderView()
+            } else {
+                ScrollView {
+                    VStack(alignment: .center, spacing: 20) {
+                        Text("Hello World")
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .background(backgroundColor)
+        .toastView(toast: $viewModel.toast)
+        .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
+        .navigationBarTitle("Record a payment", displayMode: .inline)
     }
 }
 
 #Preview {
-    GroupPaymentView()
+    GroupPaymentView(viewModel: GroupPaymentViewModel(router: nil, groupId: ""))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import BaseStyle
 
 struct GroupPaymentView: View {
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
@@ -12,19 +12,10 @@ class GroupPaymentViewModel: BaseViewModel, ObservableObject {
 
     @Inject var preference: SplitoPreference
     @Inject var groupRepository: GroupRepository
-    @Inject var expenseRepository: ExpenseRepository
 
-    @Published var group: Groups?
-    @Published var members: [AppUser] = []
     @Published var viewState: ViewState = .initial
 
-    @Published var showMoreOptionsSheet = false
-
-    @Published private var expenses: [Expense] = []
-    @Published var memberOwingAmount: [String: Double] = [:]
-
     private let groupId: String
-    private var groupMemberData: [AppUser] = []
     private let router: Router<AppRoute>?
 
     init(router: Router<AppRoute>? = nil, groupId: String) {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Amisha Italiya on 04/06/24.
 //
 
-import Foundation
+import Combine
 import Data
 
 class GroupPaymentViewModel: BaseViewModel, ObservableObject {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
@@ -6,3 +6,38 @@
 //
 
 import Foundation
+import Data
+
+class GroupPaymentViewModel: BaseViewModel, ObservableObject {
+
+    @Inject var preference: SplitoPreference
+    @Inject var groupRepository: GroupRepository
+    @Inject var expenseRepository: ExpenseRepository
+
+    @Published var group: Groups?
+    @Published var members: [AppUser] = []
+    @Published var viewState: ViewState = .initial
+
+    @Published var showMoreOptionsSheet = false
+
+    @Published private var expenses: [Expense] = []
+    @Published var memberOwingAmount: [String: Double] = [:]
+
+    private let groupId: String
+    private var groupMemberData: [AppUser] = []
+    private let router: Router<AppRoute>?
+
+    init(router: Router<AppRoute>? = nil, groupId: String) {
+        self.groupId = groupId
+        self.router = router
+        super.init()
+    }
+}
+
+// MARK: - View States
+extension GroupPaymentViewModel {
+    enum ViewState {
+        case initial
+        case loading
+    }
+}

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Data
 import BaseStyle
 
 struct GroupWhoGettingPaidView: View {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
@@ -20,7 +20,7 @@ struct GroupWhoGettingPaidView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 10) {
                         ForEach(viewModel.members) { member in
-                            GroupMemberView(member: member, selectedMemberId: viewModel.selectedMemberId)
+                            GroupPayingMemberView(member: member, selectedMemberId: viewModel.selectedMemberId)
                                 .onTouchGesture {
                                     viewModel.onMemberTap(member)
                                 }
@@ -39,6 +39,9 @@ struct GroupWhoGettingPaidView: View {
         .toastView(toast: $viewModel.toast)
         .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
         .navigationBarTitle("Who is getting paid?", displayMode: .inline)
+        .onAppear {
+            viewModel.fetchGroupMembers()
+        }
     }
 }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidView.swift
@@ -6,13 +6,43 @@
 //
 
 import SwiftUI
+import Data
+import BaseStyle
 
 struct GroupWhoGettingPaidView: View {
+
+    @StateObject var viewModel: GroupWhoGettingPaidViewModel
+
     var body: some View {
-        Text("Hello, World!")
+        VStack(alignment: .leading, spacing: 0) {
+            if case .loading = viewModel.viewState {
+                LoaderView()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(viewModel.members) { member in
+                            GroupMemberView(member: member, selectedMemberId: viewModel.selectedMemberId)
+                                .onTouchGesture {
+                                    viewModel.onMemberTap(member)
+                                }
+
+                            Divider()
+                                .frame(height: 1)
+                                .background(outlineColor.opacity(0.4))
+                        }
+                    }
+                    .padding(.top, 24)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .background(backgroundColor)
+        .toastView(toast: $viewModel.toast)
+        .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
+        .navigationBarTitle("Who is getting paid?", displayMode: .inline)
     }
 }
 
 #Preview {
-    GroupWhoGettingPaidView()
+    GroupWhoGettingPaidView(viewModel: GroupWhoGettingPaidViewModel(router: nil, groupId: "", selectedMemberId: ""))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
@@ -5,4 +5,60 @@
 //  Created by Amisha Italiya on 04/06/24.
 //
 
-import Foundation
+import Data
+import Combine
+import SwiftUI
+
+class GroupWhoGettingPaidViewModel: BaseViewModel, ObservableObject {
+
+    @Inject var groupRepository: GroupRepository
+
+    @Published var members: [AppUser] = []
+    @Published var viewState: ViewState = .initial
+
+    @Published var selectedMemberId: String
+
+    private let groupId: String
+    private let router: Router<AppRoute>?
+
+    init(router: Router<AppRoute>? = nil, groupId: String, selectedMemberId: String) {
+        self.router = router
+        self.groupId = groupId
+        self.selectedMemberId = selectedMemberId
+        super.init()
+        fetchGroupMembers()
+    }
+
+    // MARK: - Data Loading
+    private func fetchGroupMembers() {
+        groupRepository.fetchMembersBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.handleServiceError(error)
+                }
+            } receiveValue: { [weak self] members in
+                guard let self else { return }
+                self.members = members
+            }.store(in: &cancelable)
+    }
+
+    func onMemberTap(_ member: AppUser) {
+        if member.id != selectedMemberId {
+            router?.push(.GroupPaymentView(groupId: groupId))
+        }
+    }
+
+    // MARK: - Error Handling
+    private func handleServiceError(_ error: ServiceError) {
+        viewState = .initial
+        showToastFor(error)
+    }
+}
+
+// MARK: - View States
+extension GroupWhoGettingPaidViewModel {
+    enum ViewState {
+        case initial
+        case loading
+    }
+}

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
@@ -25,11 +25,10 @@ class GroupWhoGettingPaidViewModel: BaseViewModel, ObservableObject {
         self.groupId = groupId
         self.selectedMemberId = selectedMemberId
         super.init()
-        fetchGroupMembers()
     }
 
     // MARK: - Data Loading
-    private func fetchGroupMembers() {
+    func fetchGroupMembers() {
         groupRepository.fetchMembersBy(groupId: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Getting Paid/GroupWhoGettingPaidViewModel.swift
@@ -7,7 +7,6 @@
 
 import Data
 import Combine
-import SwiftUI
 
 class GroupWhoGettingPaidViewModel: BaseViewModel, ObservableObject {
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
@@ -6,13 +6,99 @@
 //
 
 import SwiftUI
+import Data
+import BaseStyle
 
 struct GroupWhoIsPayingView: View {
+
+    @StateObject var viewModel: GroupWhoIsPayingViewModel
+
     var body: some View {
-        Text("Hello, World!")
+        VStack(alignment: .leading, spacing: 0) {
+            if case .loading = viewModel.viewState {
+                LoaderView()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(viewModel.members) { member in
+                            GroupMemberView(member: member)
+                                .onTouchGesture {
+                                    viewModel.onMemberTap(member)
+                                }
+
+                            Divider()
+                                .frame(height: 1)
+                                .background(outlineColor.opacity(0.4))
+                        }
+                    }
+                    .padding(.top, 24)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .background(backgroundColor)
+        .toastView(toast: $viewModel.toast)
+        .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
+        .navigationBarTitle("Who is paying?", displayMode: .inline)
+    }
+}
+
+struct GroupMemberView: View {
+
+    @Inject var preference: SplitoPreference
+
+    let member: AppUser
+    let selectedMemberId: String?
+
+    init(member: AppUser, selectedMemberId: String? = nil) {
+        self.member = member
+        self.selectedMemberId = selectedMemberId
+    }
+
+    private var userName: String {
+        if let user = preference.user, member.id == user.id {
+            return "You"
+        } else {
+            return member.fullName
+        }
+    }
+
+    private var subInfo: String {
+        if let emailId = member.emailId {
+            return emailId
+        } else if let phoneNumber = member.phoneNumber {
+            return phoneNumber
+        } else {
+            return "No email address"
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 20) {
+            MemberProfileImageView(imageUrl: member.imageUrl)
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(alignment: .center, spacing: 2) {
+                    Text(userName.localized)
+                        .lineLimit(1)
+                        .font(.body1())
+                        .foregroundStyle(primaryText)
+                }
+
+                Text(subInfo.localized)
+                    .lineLimit(1)
+                    .font(.subTitle3())
+                    .foregroundStyle(secondaryText)
+            }
+            .lineLimit(1)
+
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .opacity(member.id == selectedMemberId ? 0.2 : 1)
     }
 }
 
 #Preview {
-    GroupWhoIsPayingView()
+    GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(groupId: ""))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
@@ -21,7 +21,7 @@ struct GroupWhoIsPayingView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 10) {
                         ForEach(viewModel.members) { member in
-                            GroupMemberView(member: member)
+                            GroupPayingMemberView(member: member)
                                 .onTouchGesture {
                                     viewModel.onMemberTap(member)
                                 }
@@ -40,10 +40,13 @@ struct GroupWhoIsPayingView: View {
         .toastView(toast: $viewModel.toast)
         .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
         .navigationBarTitle("Who is paying?", displayMode: .inline)
+        .onAppear {
+            viewModel.fetchGroupMembers()
+        }
     }
 }
 
-struct GroupMemberView: View {
+struct GroupPayingMemberView: View {
 
     @Inject var preference: SplitoPreference
 
@@ -55,19 +58,11 @@ struct GroupMemberView: View {
         self.selectedMemberId = selectedMemberId
     }
 
-    private var userName: String {
-        if let user = preference.user, member.id == user.id {
-            return "You"
-        } else {
-            return member.fullName
-        }
-    }
-
     private var subInfo: String {
-        if let emailId = member.emailId {
-            return emailId
-        } else if let phoneNumber = member.phoneNumber {
+        if let phoneNumber = member.phoneNumber, !phoneNumber.isEmpty {
             return phoneNumber
+        } else if let emailId = member.emailId, !emailId.isEmpty {
+            return emailId
         } else {
             return "No email address"
         }
@@ -79,7 +74,7 @@ struct GroupMemberView: View {
 
             VStack(alignment: .leading, spacing: 5) {
                 HStack(alignment: .center, spacing: 2) {
-                    Text(userName.localized)
+                    Text(member.fullName.localized)
                         .lineLimit(1)
                         .font(.body1())
                         .foregroundStyle(primaryText)

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
@@ -6,8 +6,8 @@
 //
 
 import SwiftUI
-import Data
 import BaseStyle
+import Data
 
 struct GroupWhoIsPayingView: View {
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
@@ -22,11 +22,10 @@ class GroupWhoIsPayingViewModel: BaseViewModel, ObservableObject {
         self.groupId = groupId
         self.router = router
         super.init()
-        fetchGroupMembers()
     }
 
     // MARK: - Data Loading
-    private func fetchGroupMembers() {
+    func fetchGroupMembers() {
         groupRepository.fetchMembersBy(groupId: groupId)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
@@ -5,4 +5,55 @@
 //  Created by Amisha Italiya on 04/06/24.
 //
 
-import Foundation
+import Data
+import Combine
+import SwiftUI
+
+class GroupWhoIsPayingViewModel: BaseViewModel, ObservableObject {
+
+    @Inject var groupRepository: GroupRepository
+
+    @Published var members: [AppUser] = []
+    @Published var viewState: ViewState = .initial
+
+    private let groupId: String
+    private let router: Router<AppRoute>?
+
+    init(router: Router<AppRoute>? = nil, groupId: String) {
+        self.groupId = groupId
+        self.router = router
+        super.init()
+        fetchGroupMembers()
+    }
+
+    // MARK: - Data Loading
+    private func fetchGroupMembers() {
+        groupRepository.fetchMembersBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.handleServiceError(error)
+                }
+            } receiveValue: { [weak self] members in
+                guard let self else { return }
+                self.members = members
+            }.store(in: &cancelable)
+    }
+
+    func onMemberTap(_ member: AppUser) {
+        router?.push(.GroupWhoGettingPaidView(groupId: groupId, selectedMemberId: member.id))
+    }
+
+    // MARK: - Error Handling
+    private func handleServiceError(_ error: ServiceError) {
+        viewState = .initial
+        showToastFor(error)
+    }
+}
+
+// MARK: - View States
+extension GroupWhoIsPayingViewModel {
+    enum ViewState {
+        case initial
+        case loading
+    }
+}

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
@@ -7,7 +7,6 @@
 
 import Data
 import Combine
-import SwiftUI
 
 class GroupWhoIsPayingViewModel: BaseViewModel, ObservableObject {
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -45,9 +45,7 @@ struct GroupHomeView: View {
         .navigationBarTitle(viewModel.group?.name ?? "", displayMode: .inline)
         .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
         .fullScreenCover(isPresented: $viewModel.showSettleUpSheet) {
-            NavigationStack {
-                GroupSettleUpView(viewModel: GroupSettleUpViewModel(groupId: viewModel.group?.id ?? ""))
-            }
+            GroupSettleUpRouteView(appRoute: Router(root: AppRoute.GroupSettleUpView(groupId: viewModel.group?.id ?? "")))
         }
         .fullScreenCover(isPresented: $viewModel.showBalancesSheet) {
             NavigationStack {


### PR DESCRIPTION
- [x] Implement who is paying screen
- [x] Implement who is getting paid screen
- [x] Add router for group settle up tab's sheet

https://github.com/canopas/splito/assets/105365731/c7568af2-3ab8-488f-b440-b92ae11af62c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced several new views for settling up group payments, including `GroupSettleUpRouteView`, `GroupWhoIsPayingView`, `GroupWhoGettingPaidView`, and `GroupPaymentView`.

- **Enhancements**
  - Improved navigation within the app by expanding the `AppRoute` enum to handle new payment-related views.
  - Updated localization strings to include new keys for payment-related actions and messages.
  
- **UI/UX Improvements**
  - Enhanced user interface in payment views with conditional content display, background colors, toast messages, and updated navigation bar titles.

- **Bug Fixes**
  - Improved error handling in view models to ensure robust data loading and error management.

- **Refactor**
  - Refactored view models to include dependency injection, state management, and Combine framework for reactive programming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->