### PR TITLE
Show payments data in totals sheet & Settle up owing amount with payment

### DIFF
--- a/Data/Data/Router/AppRoute.swift
+++ b/Data/Data/Router/AppRoute.swift
@@ -31,7 +31,7 @@ public enum AppRoute: Hashable {
     case JoinMemberView
     case GroupSettingView(groupId: String)
     case GroupSettleUpView(groupId: String)
-    case GroupWhoIsPayingView(groupId: String)
+    case GroupWhoIsPayingView(groupId: String, memberOwingAmount: [String: Double])
     case GroupWhoGettingPaidView(groupId: String, selectedMemberId: String)
     case GroupPaymentView(transactionId: String?, groupId: String, payerId: String, receiverId: String, amount: Double)
     case TransactionListView(groupId: String)

--- a/Data/Data/Router/AppRoute.swift
+++ b/Data/Data/Router/AppRoute.swift
@@ -31,7 +31,7 @@ public enum AppRoute: Hashable {
     case JoinMemberView
     case GroupSettingView(groupId: String)
     case GroupSettleUpView(groupId: String)
-    case GroupWhoIsPayingView(groupId: String, memberOwingAmount: [String: Double])
+    case GroupWhoIsPayingView(groupId: String, isPaymentSettled: Bool)
     case GroupWhoGettingPaidView(groupId: String, selectedMemberId: String)
     case GroupPaymentView(transactionId: String?, groupId: String, payerId: String, receiverId: String, amount: Double)
     case TransactionListView(groupId: String)

--- a/Splito.xcodeproj/project.pbxproj
+++ b/Splito.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0BF8F99614F85846D78DE106 /* Pods_Splito_SplitoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B9BBF3F71277A6AA5329CB /* Pods_Splito_SplitoUITests.framework */; };
 		213BA0602C0F465000116130 /* GroupSettleUpRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213BA05F2C0F465000116130 /* GroupSettleUpRouteView.swift */; };
 		213BA0662C11B70F00116130 /* HomeRouteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213BA0652C11B70F00116130 /* HomeRouteViewModel.swift */; };
+		214CF8492C2977E10044C188 /* CalculateExpensesFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214CF8482C2977E10044C188 /* CalculateExpensesFunctions.swift */; };
 		2156A8B02C24069800CFAB64 /* GroupTransactionsRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2156A8AF2C24069800CFAB64 /* GroupTransactionsRouteView.swift */; };
 		2177692B2C203160009B3B37 /* GroupTransactionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2177692A2C203160009B3B37 /* GroupTransactionDetailView.swift */; };
 		2177692D2C20316B009B3B37 /* GroupTransactionDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2177692C2C20316B009B3B37 /* GroupTransactionDetailViewModel.swift */; };
@@ -139,6 +140,7 @@
 		038CCD15E82A4E16A4AD213C /* Pods-Splito-SplitoUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Splito-SplitoUITests.release.xcconfig"; path = "Target Support Files/Pods-Splito-SplitoUITests/Pods-Splito-SplitoUITests.release.xcconfig"; sourceTree = "<group>"; };
 		213BA05F2C0F465000116130 /* GroupSettleUpRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSettleUpRouteView.swift; sourceTree = "<group>"; };
 		213BA0652C11B70F00116130 /* HomeRouteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouteViewModel.swift; sourceTree = "<group>"; };
+		214CF8482C2977E10044C188 /* CalculateExpensesFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateExpensesFunctions.swift; sourceTree = "<group>"; };
 		2156A8AF2C24069800CFAB64 /* GroupTransactionsRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupTransactionsRouteView.swift; sourceTree = "<group>"; };
 		2177692A2C203160009B3B37 /* GroupTransactionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupTransactionDetailView.swift; sourceTree = "<group>"; };
 		2177692C2C20316B009B3B37 /* GroupTransactionDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupTransactionDetailViewModel.swift; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 		D89DBE552B8DE8C600E5F1BD /* Groups */ = {
 			isa = PBXGroup;
 			children = (
+				214CF8482C2977E10044C188 /* CalculateExpensesFunctions.swift */,
 				D89DBE5A2B8DE97000E5F1BD /* GroupRouteView.swift */,
 				D88721442B9B2C78009DC5BE /* GroupListView.swift */,
 				D88721462B9B2C97009DC5BE /* GroupListViewModel.swift */,
@@ -1009,6 +1012,7 @@
 				D8302DA02B9F282F005ACA13 /* InviteMemberView.swift in Sources */,
 				D89684452B722D3400D5F721 /* SplitoApp.swift in Sources */,
 				21B1C09C2C1C5A050098B4FD /* GroupTransactionListViewModel.swift in Sources */,
+				214CF8492C2977E10044C188 /* CalculateExpensesFunctions.swift in Sources */,
 				213BA0602C0F465000116130 /* GroupSettleUpRouteView.swift in Sources */,
 				D8AC26F72B84B12800CEAAD3 /* LoginView.swift in Sources */,
 				D8CD952E2BD65F4500407B47 /* ExpenseSplitOptionsViewModel.swift in Sources */,

--- a/Splito/Localization/Localizable.xcstrings
+++ b/Splito/Localization/Localizable.xcstrings
@@ -474,6 +474,9 @@
     "you are owed" : {
 
     },
+    "You are settled up overall." : {
+
+    },
     "you borrowed" : {
 
     },

--- a/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileViewModel.swift
@@ -116,9 +116,9 @@ public class UserProfileViewModel: BaseViewModel, ObservableObject {
         guard let user = preference.user else { return }
 
         var newUser = user
-        newUser.firstName = firstName.capitalized
-        newUser.lastName = lastName.capitalized
-        newUser.emailId = email
+        newUser.firstName = firstName.trimming(spaces: .leadingAndTrailing).capitalized
+        newUser.lastName = lastName.trimming(spaces: .leadingAndTrailing).capitalized
+        newUser.emailId = email.trimming(spaces: .leadingAndTrailing)
         newUser.phoneNumber = phoneNumber
 
         let resizedImage = profileImage?.aspectFittedToHeight(200)

--- a/Splito/UI/Home/Expense/AddExpenseViewModel.swift
+++ b/Splito/UI/Home/Expense/AddExpenseViewModel.swift
@@ -209,7 +209,7 @@ extension AddExpenseViewModel {
 
         if let expense {
             var newExpense = expense
-            newExpense.name = expenseName.capitalized
+            newExpense.name = expenseName.trimming(spaces: .leadingAndTrailing).capitalized
             newExpense.amount = expenseAmount
             newExpense.date = Timestamp(date: expenseDate)
             newExpense.paidBy = selectedPayer.id
@@ -217,7 +217,7 @@ extension AddExpenseViewModel {
 
             updateExpense(expense: newExpense)
         } else {
-            let expense = Expense(name: expenseName.capitalized, amount: expenseAmount,
+            let expense = Expense(name: expenseName.trimming(spaces: .leadingAndTrailing).capitalized, amount: expenseAmount,
                                   date: Timestamp(date: expenseDate), paidBy: selectedPayer.id,
                                   addedBy: user.id, splitTo: selectedMembers, groupId: groupId)
 

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -10,11 +10,9 @@ import Combine
 
 public func calculateExpensesNonSimplify(userId: String, expenses: [Expense], transactions: [Transactions]) -> ([String: Double]) {
 
-    // To keep track of amounts the user owes to others and is owed by others
     var owesToUser: [String: Double] = [:]
     var owedByUser: [String: Double] = [:]
 
-    // Process each expense to calculate how much the user owes and is owed
     for expense in expenses {
         let splitAmount = expense.amount / Double(expense.splitTo.count)
 
@@ -29,7 +27,6 @@ public func calculateExpensesNonSimplify(userId: String, expenses: [Expense], tr
         }
     }
 
-    // Process the transactions to update the owesToUser and owedByUser
     let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, owesToUser: owesToUser, owedByUser: owedByUser)
 
     return memberOwingAmount.filter { $0.value != 0 }
@@ -41,7 +38,6 @@ public func processTransactions(userId: String, transactions: [Transactions], ow
     var owedByUser: [String: Double] = owedByUser
     var memberOwingAmount: [String: Double] = [:]
 
-    // Process each transaction to update the owesToUser and owedByUser
     for transaction in transactions {
         let payer = transaction.payerId
         let receiver = transaction.receiverId
@@ -66,7 +62,6 @@ public func processTransactions(userId: String, transactions: [Transactions], ow
         }
     }
 
-    // Consolidate the owesToUser and owedByUser into memberOwingAmount
     owesToUser.forEach { payerId, owesAmount in
         memberOwingAmount[payerId, default: 0.0] += owesAmount
     }
@@ -79,10 +74,8 @@ public func processTransactions(userId: String, transactions: [Transactions], ow
 
 public func calculateExpensesSimplify(userId: String, expenses: [Expense], transactions: [Transactions]) -> ([String: Double]) {
 
-    // To keep track of the net amount each user owes or is owed
     var ownAmounts: [String: Double] = [:]
 
-    // Process each expense to calculate net amounts
     for expense in expenses {
         ownAmounts[expense.paidBy, default: 0.0] += expense.amount
         let splitAmount = expense.amount / Double(expense.splitTo.count)
@@ -92,7 +85,6 @@ public func calculateExpensesSimplify(userId: String, expenses: [Expense], trans
         }
     }
 
-    // Process the transactions and settle debts
     let owingAmount = processTransactionsSimply(userId: userId, transactions: transactions, ownAmounts: ownAmounts)
 
     return owingAmount.filter { $0.value != 0 }
@@ -100,17 +92,14 @@ public func calculateExpensesSimplify(userId: String, expenses: [Expense], trans
 
 public func processTransactionsSimply(userId: String, transactions: [Transactions], ownAmounts: [String: Double]) -> ([String: Double]) {
 
-    // To keep track of the final amounts each user owes or is owed
     var memberOwingAmount: [String: Double] = [:]
 
     // Settle debts among users
     let debts = settleDebts(users: ownAmounts)
     for debt in debts where debt.0 == userId || debt.1 == userId {
-        // Update the amounts for the user
-        memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
+        memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2  // Update the amounts for the user
     }
 
-    // Process each transaction to update the memberOwingAmount
     for transaction in transactions {
         let payer = transaction.payerId
         let receiver = transaction.receiverId

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -1,0 +1,128 @@
+//
+//  CalculateExpensesFunctions.swift
+//  Splito
+//
+//  Created by Nirali Sonani on 24/06/24.
+//
+
+import Data
+import Combine
+
+public func calculateExpensesSimplify(userId: String, expenses: [Expense], transactions: [Transactions]) -> ([String: Double]) {
+
+    var ownAmounts: [String: Double] = [:]
+    var memberOwingAmount: [String: Double] = [:]
+
+    for expense in expenses {
+        ownAmounts[expense.paidBy, default: 0.0] += expense.amount
+        let splitAmount = expense.amount / Double(expense.splitTo.count)
+
+        for member in expense.splitTo {
+            ownAmounts[member, default: 0.0] -= splitAmount
+        }
+    }
+
+    let debts = settleDebts(users: ownAmounts)
+    for debt in debts where debt.0 == userId || debt.1 == userId {
+        memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
+    }
+
+    for transaction in transactions {
+        let payer = transaction.payerId
+        let receiver = transaction.receiverId
+        let amount = transaction.amount
+
+        if payer == userId, let currentAmount = memberOwingAmount[receiver] {
+            memberOwingAmount[receiver] = currentAmount + amount
+        } else if receiver == userId, let currentAmount = memberOwingAmount[payer] {
+            memberOwingAmount[payer] = currentAmount - amount
+        }
+    }
+
+    return memberOwingAmount.filter { $0.value != 0 }
+}
+
+public func calculateExpensesNonSimplify(userId: String, expenses: [Expense], transactions: [Transactions]) -> ([String: Double]) {
+
+    var expenseByUser = 0.0
+    var owesToUser: [String: Double] = [:]
+    var owedByUser: [String: Double] = [:]
+
+    for expense in expenses {
+        let splitAmount = expense.amount / Double(expense.splitTo.count)
+        if expense.paidBy == userId {
+            expenseByUser += expense.splitTo.contains(userId) ? expense.amount - splitAmount : expense.amount
+            for member in expense.splitTo where member != userId {
+                owesToUser[member, default: 0.0] += splitAmount
+            }
+        } else if expense.splitTo.contains(where: { $0 == userId }) {
+            expenseByUser -= splitAmount
+            owedByUser[expense.paidBy, default: 0.0] += splitAmount
+        }
+    }
+
+    let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, owesToUser: owesToUser, owedByUser: owedByUser)
+
+    return memberOwingAmount.filter { $0.value != 0 }
+}
+
+public func processTransactions(userId: String, transactions: [Transactions], owesToUser: [String: Double], owedByUser: [String: Double]) -> ([String: Double]) {
+
+    var owesToUser: [String: Double] = owesToUser
+    var owedByUser: [String: Double] = owedByUser
+    var memberOwingAmount: [String: Double] = [:]
+
+    for transaction in transactions {
+        let payer = transaction.payerId
+        let receiver = transaction.receiverId
+        let amount = transaction.amount
+
+        if transaction.payerId == userId {
+            if owedByUser[receiver] != nil {
+                owesToUser[transaction.receiverId, default: 0.0] += amount
+            } else {
+                owedByUser[transaction.payerId, default: 0.0] -= amount
+            }
+        } else if transaction.receiverId == userId {
+            if owesToUser[payer] != nil {
+                owedByUser[transaction.payerId, default: 0.0] += amount
+            } else {
+                owesToUser[payer] = -amount
+            }
+        }
+    }
+
+    owesToUser.forEach { payerId, owesAmount in
+        memberOwingAmount[payerId, default: 0.0] += owesAmount
+    }
+    owedByUser.forEach { receiverId, owedAmount in
+        memberOwingAmount[receiverId, default: 0.0] -= owedAmount
+    }
+
+    return memberOwingAmount
+}
+
+public func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
+    var mutableUsers = users
+    var debts: [(String, String, Double)] = []
+    let positiveAmounts = mutableUsers.filter { $0.value > 0 }
+    let negativeAmounts = mutableUsers.filter { $0.value < 0 }
+
+    for (creditor, creditAmount) in positiveAmounts {
+        var remainingCredit = creditAmount
+
+        for (debtor, debtAmount) in negativeAmounts {
+            if remainingCredit == 0 { break }
+            let amountToSettle = min(remainingCredit, -debtAmount)
+
+            if amountToSettle > 0 {
+                debts.append((debtor, creditor, amountToSettle))
+                remainingCredit -= amountToSettle
+                mutableUsers[debtor]! += amountToSettle
+                mutableUsers[creditor]! -= amountToSettle
+            }
+        }
+    }
+
+    return debts
+}

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -143,3 +143,23 @@ public func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
 
     return debts
 }
+
+public func calculateSettingsExpenses(expenses: [Expense], transactions: [Transactions]) -> [String: Double] {
+    var amountOweByMember: [String: Double] = [:]
+
+    for expense in expenses {
+        amountOweByMember[expense.paidBy, default: 0.0] += expense.amount
+
+        let splitAmount = expense.amount / Double(expense.splitTo.count)
+        for member in expense.splitTo {
+            amountOweByMember[member, default: 0.0] -= splitAmount
+        }
+    }
+
+    for transaction in transactions {
+        amountOweByMember[transaction.payerId, default: 0.0] += transaction.amount
+        amountOweByMember[transaction.receiverId, default: 0.0] -= transaction.amount
+    }
+
+    return amountOweByMember
+}

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -136,6 +136,7 @@ public func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
     return debts
 }
 
+// Used in settings and totals screen's total change in balance calculation
 public func calculateTransactionsWithExpenses(expenses: [Expense], transactions: [Transactions]) -> [String: Double] {
     var amountOweByMember: [String: Double] = [:]
 

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -86,19 +86,19 @@ public func calculateExpensesSimplify(userId: String, expenses: [Expense], trans
         }
     }
 
-    memberOwingAmount = processTransactionsSimply(userId: userId, transactions: transactions, memberOwingAmount: ownAmounts)
-
     let debts = settleDebts(users: ownAmounts)
     for debt in debts where debt.0 == userId || debt.1 == userId {
         memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
     }
+
+    memberOwingAmount = processTransactionsSimply(userId: userId, transactions: transactions, memberOwingAmount: memberOwingAmount)
 
     return memberOwingAmount.filter { $0.value != 0 }
 }
 
 public func processTransactionsSimply(userId: String, transactions: [Transactions], memberOwingAmount: [String: Double]) -> ([String: Double]) {
 
-    var memberOwingAmount: [String: Double] = [:]
+    var memberOwingAmount: [String: Double] = memberOwingAmount
 
     for transaction in transactions {
         let payer = transaction.payerId

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -2,7 +2,7 @@
 //  CalculateExpensesFunctions.swift
 //  Splito
 //
-//  Created by Nirali Sonani on 24/06/24.
+//  Created by Amisha Italiya on 24/06/24.
 //
 
 import Data

--- a/Splito/UI/Home/Groups/Create Group/CreateGroupViewModel.swift
+++ b/Splito/UI/Home/Groups/Create Group/CreateGroupViewModel.swift
@@ -93,7 +93,7 @@ class CreateGroupViewModel: BaseViewModel, ObservableObject {
     private func createGroup() {
         currentState = .loading
         let userId = preference.user?.id ?? ""
-        let group = Groups(name: groupName.capitalized, createdBy: userId, members: [userId], imageUrl: nil, createdAt: Timestamp())
+        let group = Groups(name: groupName.trimming(spaces: .leadingAndTrailing).capitalized, createdBy: userId, members: [userId], imageUrl: nil, createdAt: Timestamp())
 
         let resizedImage = profileImage?.aspectFittedToHeight(200)
         let imageData = resizedImage?.jpegData(compressionQuality: 0.2)

--- a/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Data
 import BaseStyle
 
 struct GroupBalancesView: View {

--- a/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
@@ -85,7 +85,7 @@ class GroupBalancesViewModel: BaseViewModel, ObservableObject {
     }
 
     private func calculateExpenses(expenses: [Expense]) {
-        let groupMembers = Array(Set(expenses.flatMap { $0.splitTo + [$0.paidBy] }))
+        let groupMembers = Array(Set(groupMemberData.map { $0.id }))
         var memberBalances = groupMembers.map { GroupMemberBalance(id: $0) }
 
         for expense in expenses {
@@ -123,7 +123,7 @@ class GroupBalancesViewModel: BaseViewModel, ObservableObject {
     }
 
     private func calculateExpensesSimply(expenses: [Expense]) {
-        let groupMembers = Array(Set(expenses.flatMap { $0.splitTo + [$0.paidBy] }))
+        let groupMembers = Array(Set(groupMemberData.map { $0.id }))
         var memberBalances = groupMembers.map { GroupMemberBalance(id: $0) }
 
         for expense in expenses {

--- a/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
@@ -10,9 +10,9 @@ import Foundation
 
 class GroupBalancesViewModel: BaseViewModel, ObservableObject {
 
-    @Inject var preference: SplitoPreference
-    @Inject var groupRepository: GroupRepository
-    @Inject var expenseRepository: ExpenseRepository
+    @Inject private var preference: SplitoPreference
+    @Inject private var groupRepository: GroupRepository
+    @Inject private var expenseRepository: ExpenseRepository
     @Inject private var transactionRepository: TransactionRepository
 
     @Published var viewState: ViewState = .initial

--- a/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
@@ -64,7 +64,6 @@ class GroupBalancesViewModel: BaseViewModel, ObservableObject {
             }
         } receiveValue: { [weak self] transactions in
             self?.transactions = transactions
-            print("xxx \(transactions)")
         }.store(in: &cancelable)
     }
 
@@ -77,7 +76,6 @@ class GroupBalancesViewModel: BaseViewModel, ObservableObject {
                 }
             } receiveValue: { [weak self] expenses in
                 guard let self else { return }
-                print("xxx \(expenses)")
                 if group.isDebtSimplified {
                     calculateExpensesSimply(expenses: expenses)
                 } else {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
@@ -26,8 +26,8 @@ struct GroupSettleUpRouteView: View {
             case .GroupSettleUpView(let groupId):
                 GroupSettleUpView(viewModel: GroupSettleUpViewModel(router: appRoute, groupId: groupId))
 
-            case .GroupWhoIsPayingView(let groupId, let memberOwingAmount):
-                GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(router: appRoute, groupId: groupId, memberOwingAmount: memberOwingAmount))
+            case .GroupWhoIsPayingView(let groupId, let isPaymentSettled):
+                GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(router: appRoute, groupId: groupId, isPaymentSettled: isPaymentSettled))
 
             case .GroupWhoGettingPaidView(let groupId, let selectedMemberId):
                 GroupWhoGettingPaidView(viewModel: GroupWhoGettingPaidViewModel(router: appRoute,

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpRouteView.swift
@@ -26,8 +26,8 @@ struct GroupSettleUpRouteView: View {
             case .GroupSettleUpView(let groupId):
                 GroupSettleUpView(viewModel: GroupSettleUpViewModel(router: appRoute, groupId: groupId))
 
-            case .GroupWhoIsPayingView(let groupId):
-                GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(router: appRoute, groupId: groupId))
+            case .GroupWhoIsPayingView(let groupId, let memberOwingAmount):
+                GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(router: appRoute, groupId: groupId, memberOwingAmount: memberOwingAmount))
 
             case .GroupWhoGettingPaidView(let groupId, let selectedMemberId):
                 GroupWhoGettingPaidView(viewModel: GroupWhoGettingPaidViewModel(router: appRoute,

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -61,7 +61,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
                 self.members = members
                 self.members.removeAll(where: { $0.id == user.id })
                 self.fetchTransactions()
-                self.fetchExpenses()
             }.store(in: &cancelable)
     }
 
@@ -73,6 +72,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
         } receiveValue: { [weak self] transactions in
             guard let self else { return }
             self.transactions = transactions
+            self.fetchExpenses()
         }.store(in: &cancelable)
     }
 
@@ -83,124 +83,15 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
                     self?.handleServiceError(error)
                 }
             } receiveValue: { [weak self] expenses in
-                guard let self, let group else { return }
+                guard let self, let group, let userId = preference.user?.id else { return }
                 self.expenses = expenses
+                memberOwingAmount = [:]
                 if group.isDebtSimplified {
-                    self.calculateExpensesSimply()
+                    self.memberOwingAmount = calculateExpensesSimplify(userId: userId, expenses: expenses, transactions: transactions)
                 } else {
-                    self.calculateExpenses()
+                    self.memberOwingAmount = calculateExpensesNonSimplify(userId: userId, expenses: expenses, transactions: transactions)
                 }
             }.store(in: &cancelable)
-    }
-
-    private func calculateExpenses() {
-        guard let userId = preference.user?.id else { return }
-
-        var owesToUser: [String: Double] = [:]
-        var owedByUser: [String: Double] = [:]
-
-        memberOwingAmount = [:]
-
-        for expense in expenses {
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-
-            if expense.paidBy == userId {
-                for member in expense.splitTo where member != userId {
-                    owesToUser[member, default: 0.0] += splitAmount
-                }
-            } else if expense.splitTo.contains(userId) {
-                owedByUser[expense.paidBy, default: 0.0] += splitAmount
-            }
-        }
-
-        for transaction in transactions {
-            let payer = transaction.payerId
-            let receiver = transaction.receiverId
-            let amount = transaction.amount
-
-            if transaction.payerId == userId {
-                if owedByUser[receiver] != nil {
-                    owesToUser[transaction.receiverId, default: 0.0] += amount
-                } else {
-                    owedByUser[transaction.payerId, default: 0.0] -= amount
-                }
-            } else if transaction.receiverId == userId {
-                if owesToUser[payer] != nil {
-                    owedByUser[transaction.payerId, default: 0.0] += amount
-                } else {
-                    owesToUser[payer] = -amount
-                }
-            }
-        }
-
-        owesToUser.forEach { payerId, owesAmount in
-            memberOwingAmount[payerId, default: 0.0] += owesAmount
-        }
-        owedByUser.forEach { receiverId, owedAmount in
-            memberOwingAmount[receiverId, default: 0.0] -= owedAmount
-        }
-
-        memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
-    }
-
-    private func calculateExpensesSimply() {
-        guard let userId = preference.user?.id else { return }
-
-        var ownAmounts: [String: Double] = [:]
-
-        memberOwingAmount = [:]
-
-        for expense in expenses {
-            ownAmounts[expense.paidBy, default: 0.0] += expense.amount
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-
-            for member in expense.splitTo {
-                ownAmounts[member, default: 0.0] -= splitAmount
-            }
-        }
-
-        let debts = settleDebts(users: ownAmounts)
-        for debt in debts where debt.0 == userId || debt.1 == userId {
-            memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
-        }
-
-        for transaction in transactions {
-            let payer = transaction.payerId
-            let receiver = transaction.receiverId
-            let amount = transaction.amount
-
-            if payer == userId, let currentAmount = memberOwingAmount[receiver] {
-                memberOwingAmount[receiver] = currentAmount + amount
-            } else if receiver == userId, let currentAmount = memberOwingAmount[payer] {
-                memberOwingAmount[payer] = currentAmount - amount
-            }
-        }
-
-        memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
-    }
-
-    private func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
-        var mutableUsers = users
-        var debts: [(String, String, Double)] = []
-        let positiveAmounts = mutableUsers.filter { $0.value > 0 }
-        let negativeAmounts = mutableUsers.filter { $0.value < 0 }
-
-        for (creditor, creditAmount) in positiveAmounts {
-            var remainingCredit = creditAmount
-
-            for (debtor, debtAmount) in negativeAmounts {
-                if remainingCredit == 0 { break }
-                let amountToSettle = min(remainingCredit, -debtAmount)
-                if amountToSettle > 0 {
-                    debts.append((debtor, creditor, amountToSettle))
-                    remainingCredit -= amountToSettle
-                    mutableUsers[debtor]! += amountToSettle
-                    mutableUsers[creditor]! -= amountToSettle
-                }
-            }
-        }
-
-        return debts
     }
 
     func getMemberDataBy(id: String) -> AppUser? {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -99,7 +99,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
 
     // MARK: - User Actions
     func handleMoreButtonTap() {
-        router?.push(.GroupWhoIsPayingView(groupId: groupId))
+        router?.push(.GroupWhoIsPayingView(groupId: groupId, memberOwingAmount: memberOwingAmount))
     }
 
     func onMemberTap(memberId: String, amount: Double) {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -61,6 +61,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
                 self.members = members
                 self.members.removeAll(where: { $0.id == user.id })
                 self.fetchTransactions()
+                self.fetchExpenses()
             }.store(in: &cancelable)
     }
 
@@ -72,7 +73,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
         } receiveValue: { [weak self] transactions in
             guard let self else { return }
             self.transactions = transactions
-            self.fetchExpenses()
         }.store(in: &cancelable)
     }
 
@@ -85,7 +85,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] expenses in
                 guard let self, let group, let userId = preference.user?.id else { return }
                 self.expenses = expenses
-                memberOwingAmount = [:]
                 if group.isDebtSimplified {
                     self.memberOwingAmount = calculateExpensesSimplify(userId: userId, expenses: expenses, transactions: transactions)
                 } else {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -72,7 +72,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
             }
         } receiveValue: { [weak self] transactions in
             guard let self else { return }
-            print("transactions data: \(transactions)")
             self.transactions = transactions
         }.store(in: &cancelable)
     }
@@ -86,7 +85,6 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] expenses in
                 guard let self, let group else { return }
                 self.expenses = expenses
-                print("expenses data: \(expenses)")
                 if group.isDebtSimplified {
                     self.calculateExpensesSimply()
                 } else {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpViewModel.swift
@@ -99,7 +99,7 @@ class GroupSettleUpViewModel: BaseViewModel, ObservableObject {
 
     // MARK: - User Actions
     func handleMoreButtonTap() {
-        router?.push(.GroupWhoIsPayingView(groupId: groupId, memberOwingAmount: memberOwingAmount))
+        router?.push(.GroupWhoIsPayingView(groupId: groupId, isPaymentSettled: false))
     }
 
     func onMemberTap(memberId: String, amount: Double) {

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
@@ -14,11 +14,11 @@ struct GroupPaymentView: View {
     @StateObject var viewModel: GroupPaymentViewModel
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            if case .loading = viewModel.viewState {
-                LoaderView()
-            } else {
-                ScrollView {
+        ScrollView {
+            VStack(alignment: .center, spacing: 0) {
+                if case .loading = viewModel.viewState {
+                    LoaderView()
+                } else {
                     VStack(alignment: .center, spacing: 20) {
                         VSpacer(80)
 
@@ -52,26 +52,26 @@ struct GroupPaymentView: View {
 
                         VSpacer(20)
                     }
-                }
-                .padding(.horizontal, 20)
-                .scrollIndicators(.hidden)
-            }
-        }
-        .background(backgroundColor)
-        .toastView(toast: $viewModel.toast)
-        .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
-        .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
-        .navigationBarTitle(viewModel.transactionId != nil ? "Edit payment" : "Record a payment", displayMode: .inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Save", action: viewModel.handleSaveAction)
-            }
-            if viewModel.transactionId != nil {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel", action: viewModel.dismissPaymentFlow)
+                    .padding(.horizontal, 20)
                 }
             }
+            .background(backgroundColor)
+            .toastView(toast: $viewModel.toast)
+            .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
+            .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
+            .navigationBarTitle(viewModel.transactionId != nil ? "Edit payment" : "Record a payment", displayMode: .inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save", action: viewModel.handleSaveAction)
+                }
+                if viewModel.transactionId != nil {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Cancel", action: viewModel.dismissPaymentFlow)
+                    }
+                }
+            }
         }
+        .scrollIndicators(.hidden)
     }
 }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
@@ -13,6 +13,8 @@ struct GroupWhoIsPayingView: View {
 
     @StateObject var viewModel: GroupWhoIsPayingViewModel
 
+    @Environment(\.dismiss) var dismiss
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if case .loading = viewModel.viewState {
@@ -41,8 +43,15 @@ struct GroupWhoIsPayingView: View {
         .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
         .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
         .navigationBarTitle("Who is paying?", displayMode: .inline)
-        .onAppear {
-            viewModel.fetchGroupMembers()
+        .onAppear(perform: viewModel.fetchGroupMembers)
+        .toolbar {
+            if viewModel.memberOwingAmount.isEmpty {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
         }
     }
 }
@@ -96,5 +105,5 @@ struct GroupPayingMemberView: View {
 }
 
 #Preview {
-    GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(groupId: ""))
+    GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(groupId: "", memberOwingAmount: [:]))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingView.swift
@@ -45,7 +45,7 @@ struct GroupWhoIsPayingView: View {
         .navigationBarTitle("Who is paying?", displayMode: .inline)
         .onAppear(perform: viewModel.fetchGroupMembers)
         .toolbar {
-            if viewModel.memberOwingAmount.isEmpty {
+            if viewModel.isPaymentSettled {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         dismiss()
@@ -105,5 +105,5 @@ struct GroupPayingMemberView: View {
 }
 
 #Preview {
-    GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(groupId: "", memberOwingAmount: [:]))
+    GroupWhoIsPayingView(viewModel: GroupWhoIsPayingViewModel(groupId: "", isPaymentSettled: true))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
@@ -10,16 +10,18 @@ import Combine
 
 class GroupWhoIsPayingViewModel: BaseViewModel, ObservableObject {
 
-    @Inject var groupRepository: GroupRepository
+    @Inject private var groupRepository: GroupRepository
 
-    @Published var members: [AppUser] = []
-    @Published var viewState: ViewState = .initial
+    @Published private(set) var members: [AppUser] = []
+    @Published private(set) var viewState: ViewState = .initial
+    @Published private(set) var memberOwingAmount: [String: Double]
 
     private let groupId: String
     private let router: Router<AppRoute>?
 
-    init(router: Router<AppRoute>? = nil, groupId: String) {
+    init(router: Router<AppRoute>? = nil, groupId: String, memberOwingAmount: [String: Double]) {
         self.groupId = groupId
+        self.memberOwingAmount = memberOwingAmount
         self.router = router
         super.init()
     }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Who Is paying/GroupWhoIsPayingViewModel.swift
@@ -14,14 +14,15 @@ class GroupWhoIsPayingViewModel: BaseViewModel, ObservableObject {
 
     @Published private(set) var members: [AppUser] = []
     @Published private(set) var viewState: ViewState = .initial
-    @Published private(set) var memberOwingAmount: [String: Double]
+
+    @Published private(set) var isPaymentSettled: Bool
 
     private let groupId: String
     private let router: Router<AppRoute>?
 
-    init(router: Router<AppRoute>? = nil, groupId: String, memberOwingAmount: [String: Double]) {
+    init(router: Router<AppRoute>? = nil, groupId: String, isPaymentSettled: Bool) {
         self.groupId = groupId
-        self.memberOwingAmount = memberOwingAmount
+        self.isPaymentSettled = isPaymentSettled
         self.router = router
         super.init()
     }

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
@@ -101,7 +101,7 @@ private struct GroupTotalSummaryView: View {
     }
 
     private var totalShare: Double {
-        viewModel.getTotalShareAmount()
+        return viewModel.getTotalShareAmount()
     }
 
     private var totalChangeInBalance: Double {
@@ -109,11 +109,11 @@ private struct GroupTotalSummaryView: View {
     }
 
     private var paymentsMade: Double {
-        return 0 // Add calculation for payments made
+        return viewModel.getPaymentsMade()
     }
 
     private var paymentsReceived: Double {
-        return 0 // Add calculation for payments received
+        return viewModel.getPaymentsReceived()
     }
 
     var body: some View {
@@ -124,7 +124,7 @@ private struct GroupTotalSummaryView: View {
             GroupSummaryAmountView(text: "Payments made", amount: paymentsMade)
             GroupSummaryAmountView(text: "Payments received", amount: paymentsReceived)
             GroupSummaryAmountView(text: "Total change in balance", amount: totalChangeInBalance,
-                             fontColor: (totalChangeInBalance < 0 ? amountBorrowedColor : amountLentColor))
+                                   fontColor: (totalChangeInBalance < 0 ? amountBorrowedColor : amountLentColor))
         }
         .padding(.horizontal, 4)
     }

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import BaseStyle
-import Data
 
 struct GroupTotalsView: View {
 
@@ -35,11 +34,9 @@ struct GroupTotalsView: View {
                     }
                     .padding(.horizontal, 16)
                 }
-                .scrollIndicators(.hidden)
             }
         }
         .background(backgroundColor)
-        .interactiveDismissDisabled()
         .toastView(toast: $viewModel.toast)
         .backport.alert(isPresented: $viewModel.showAlert, alertStruct: viewModel.alert)
         .navigationBarTitle("Group spending summary", displayMode: .inline)

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsView.swift
@@ -34,6 +34,7 @@ struct GroupTotalsView: View {
                     }
                     .padding(.horizontal, 16)
                 }
+                .scrollIndicators(.hidden)
             }
         }
         .background(backgroundColor)

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -43,8 +43,8 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] group in
                 guard let self, let group else { return }
                 self.group = group
-                self.fetchExpenses(group: group)
                 self.fetchTransactions()
+                self.fetchExpenses(group: group)
                 self.viewState = .initial
             }.store(in: &cancelable)
     }

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -10,10 +10,10 @@ import SwiftUI
 
 class GroupTotalsViewModel: BaseViewModel, ObservableObject {
 
-    @Inject var preference: SplitoPreference
-    @Inject var groupRepository: GroupRepository
-    @Inject var expenseRepository: ExpenseRepository
-    @Inject var transactionRepository: TransactionRepository
+    @Inject private var preference: SplitoPreference
+    @Inject private var groupRepository: GroupRepository
+    @Inject private var expenseRepository: ExpenseRepository
+    @Inject private var transactionRepository: TransactionRepository
 
     @Published private(set) var viewState: ViewState = .initial
     @Published private(set) var selectedTab: GroupTotalsTabType = .thisMonth
@@ -62,7 +62,7 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
             }.store(in: &cancelable)
     }
 
-    func fetchTransactions() {
+    private func fetchTransactions() {
         transactionRepository.fetchTransactionsBy(groupId: groupId).sink { [weak self] completion in
             if case .failure(let error) = completion {
                 self?.handleServiceError(error)

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -173,22 +173,7 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
     func getTotalChangeInBalance() -> Double {
         guard let user = preference.user else { return 0 }
 
-        var amountOweByMember: [String: Double] = [:]
-
-        for expense in filteredExpenses {
-            amountOweByMember[expense.paidBy, default: 0.0] += expense.amount
-
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-            for member in expense.splitTo {
-                amountOweByMember[member, default: 0.0] -= splitAmount
-            }
-        }
-
-        for transaction in filteredTransactions {
-            amountOweByMember[transaction.payerId, default: 0.0] += transaction.amount
-            amountOweByMember[transaction.receiverId, default: 0.0] -= transaction.amount
-        }
-
+        let amountOweByMember = calculateSettingsExpenses(expenses: filteredExpenses, transactions: filteredTransactions)
         return amountOweByMember[user.id] ?? 0
     }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -187,6 +187,12 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
                 amountOweByMember[member, default: 0.0] -= splitAmount
             }
         }
+
+        for transaction in filteredTransactions {
+            amountOweByMember[transaction.payerId, default: 0.0] += transaction.amount
+            amountOweByMember[transaction.receiverId, default: 0.0] -= transaction.amount
+        }
+
         return amountOweByMember[user.id] ?? 0
     }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -173,7 +173,7 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
     func getTotalChangeInBalance() -> Double {
         guard let user = preference.user else { return 0 }
 
-        let amountOweByMember = calculateSettingsExpenses(expenses: filteredExpenses, transactions: filteredTransactions)
+        let amountOweByMember = calculateTransactionsWithExpenses(expenses: filteredExpenses, transactions: filteredTransactions)
         return amountOweByMember[user.id] ?? 0
     }
 

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -99,11 +99,7 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
         )
     }
 
-    private func filterItemsForSelectedTab<T>(
-        items: [T],
-        dateExtractor: (T) -> Date,
-        for tab: GroupTotalsTabType
-    ) -> [T] {
+    private func filterItemsForSelectedTab<T>(items: [T], dateExtractor: (T) -> Date, for tab: GroupTotalsTabType) -> [T] {
         let calendar = Calendar.current
 
         switch tab {

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
@@ -57,7 +57,7 @@ class GroupTransactionListViewModel: BaseViewModel, ObservableObject {
                 self?.handleServiceError(error)
             }
         } receiveValue: { [weak self] transactions in
-            guard let self, !self.transactions.isEmpty else { return }
+            guard let self else { return }
             self.transactions = transactions
             self.combinedTransactionsWithUser()
         }.store(in: &cancelable)

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailView.swift
@@ -32,6 +32,7 @@ struct GroupTransactionDetailView: View {
                             .font(.body2())
                             .lineSpacing(2)
                             .foregroundStyle(disableText)
+                            .multilineTextAlignment(.center)
                             .padding(.horizontal, 16)
 
                         VSpacer()

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -174,7 +174,7 @@ struct GroupExpenseHeaderView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(viewModel.group?.name ?? "")
                 .font(.body2(28))
-                .foregroundColor(primaryText)
+                .foregroundStyle(primaryText)
 
             if viewModel.overallOwingAmount == 0 {
                 Text(viewModel.memberOwingAmount.isEmpty ? "You are all settled up in this group." : "You are settled up overall.")

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -169,7 +169,7 @@ private struct GroupExpenseItemView: View {
 }
 
 private struct GroupExpenseHeaderView: View {
-    
+
     @ObservedObject var viewModel: GroupHomeViewModel
 
     var body: some View {

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -182,10 +182,10 @@ private struct GroupExpenseHeaderView: View {
             } else {
                 if viewModel.memberOwingAmount.count < 2, let member = viewModel.memberOwingAmount.first {
                     let name = viewModel.getMemberDataBy(id: member.key)?.nameWithLastInitial ?? "Unknown"
-                    GroupExpenseMemberOweView(name: name, amount: viewModel.overallOwingAmount)
+                    GroupExpenseMemberOweView(name: name, amount: member.value)
                 } else {
                     let isDue = viewModel.overallOwingAmount < 0
-                    Text("You \(isDue ? "owe" : "are owed") \(viewModel.overallOwingAmount.formattedCurrency) overall")
+                    Text("You \(isDue ? "owe" : "are owed") \(abs(viewModel.overallOwingAmount).formattedCurrency) overall")
                         .font(.subTitle2())
                         .foregroundStyle(isDue ? amountBorrowedColor : amountLentColor)
 

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -177,23 +177,25 @@ struct GroupExpenseHeaderView: View {
                 .foregroundColor(.primary)
 
             if viewModel.overallOwingAmount == 0 {
-                Text("You are all settled up in this group.")
+                Text(viewModel.memberOwingAmount.isEmpty ? "You are all settled up in this group." : "You are settled up overall.")
                     .font(.subTitle2())
+            }
+
+            if viewModel.memberOwingAmount.count < 2, let member = viewModel.memberOwingAmount.first {
+                let name = viewModel.getMemberDataBy(id: member.key)?.nameWithLastInitial ?? "Unknown"
+                GroupExpenseMemberOweView(name: name, amount: member.value)
             } else {
-                if viewModel.memberOwingAmount.count < 2, let member = viewModel.memberOwingAmount.first {
-                    let name = viewModel.getMemberDataBy(id: member.key)?.nameWithLastInitial ?? "Unknown"
-                    GroupExpenseMemberOweView(name: name, amount: member.value)
-                } else {
+                if viewModel.overallOwingAmount != 0 {
                     let isDue = viewModel.overallOwingAmount < 0
                     Text("You \(isDue ? "owe" : "are owed") \(abs(viewModel.overallOwingAmount).formattedCurrency) overall")
                         .font(.subTitle2())
                         .foregroundColor(isDue ? amountBorrowedColor : amountLentColor)
+                }
 
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach(viewModel.memberOwingAmount.sorted(by: { $0.key < $1.key }), id: \.key) { (memberId, amount) in
-                            let name = viewModel.getMemberDataBy(id: memberId)?.nameWithLastInitial ?? "Unknown"
-                            GroupExpenseMemberOweView(name: name, amount: amount)
-                        }
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(viewModel.memberOwingAmount.sorted(by: { $0.key < $1.key }), id: \.key) { (memberId, amount) in
+                        let name = viewModel.getMemberDataBy(id: memberId)?.nameWithLastInitial ?? "Unknown"
+                        GroupExpenseMemberOweView(name: name, amount: amount)
                     }
                 }
             }

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -167,18 +167,18 @@ private struct GroupExpenseItemView: View {
     }
 }
 
-private struct GroupExpenseHeaderView: View {
-
+struct GroupExpenseHeaderView: View {
     @ObservedObject var viewModel: GroupHomeViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(viewModel.group?.name ?? "")
                 .font(.body2(28))
-                .foregroundStyle(primaryText)
+                .foregroundColor(.primary)
 
             if viewModel.overallOwingAmount == 0 {
-                Text("You are all settled up in this group.") // no due or lent
+                Text("You are all settled up in this group.")
+                    .font(.subTitle2())
             } else {
                 if viewModel.memberOwingAmount.count < 2, let member = viewModel.memberOwingAmount.first {
                     let name = viewModel.getMemberDataBy(id: member.key)?.nameWithLastInitial ?? "Unknown"
@@ -187,7 +187,7 @@ private struct GroupExpenseHeaderView: View {
                     let isDue = viewModel.overallOwingAmount < 0
                     Text("You \(isDue ? "owe" : "are owed") \(abs(viewModel.overallOwingAmount).formattedCurrency) overall")
                         .font(.subTitle2())
-                        .foregroundStyle(isDue ? amountBorrowedColor : amountLentColor)
+                        .foregroundColor(isDue ? amountBorrowedColor : amountLentColor)
 
                     VStack(alignment: .leading, spacing: 6) {
                         ForEach(viewModel.memberOwingAmount.sorted(by: { $0.key < $1.key }), id: \.key) { (memberId, amount) in

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -169,6 +169,7 @@ private struct GroupExpenseItemView: View {
 }
 
 private struct GroupExpenseHeaderView: View {
+    
     @ObservedObject var viewModel: GroupHomeViewModel
 
     var body: some View {

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -36,7 +36,8 @@ struct GroupExpenseListView: View {
                     Group {
                         GroupExpenseHeaderView(viewModel: viewModel)
 
-                        GroupOptionsListView(isSettleUpEnable: viewModel.group?.members.count ?? 1 > 1,
+                        GroupOptionsListView(isSettleUpEnable: (!viewModel.memberOwingAmount.isEmpty && viewModel.group?.members.count ?? 1 > 1),
+                                             showTransactionsOption: !viewModel.transactions.isEmpty,
                                              onSettleUpTap: viewModel.handleSettleUpBtnTap,
                                              onTransactionsTap: viewModel.handleTransactionsBtnTap,
                                              onBalanceTap: viewModel.handleBalancesBtnTap,
@@ -167,7 +168,7 @@ private struct GroupExpenseItemView: View {
     }
 }
 
-struct GroupExpenseHeaderView: View {
+private struct GroupExpenseHeaderView: View {
     @ObservedObject var viewModel: GroupHomeViewModel
 
     var body: some View {

--- a/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupExpenseListView.swift
@@ -174,7 +174,7 @@ struct GroupExpenseHeaderView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(viewModel.group?.name ?? "")
                 .font(.body2(28))
-                .foregroundColor(.primary)
+                .foregroundColor(primaryText)
 
             if viewModel.overallOwingAmount == 0 {
                 Text(viewModel.memberOwingAmount.isEmpty ? "You are all settled up in this group." : "You are settled up overall.")

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -97,11 +97,11 @@ struct GroupOptionsListView: View {
             HStack(spacing: 16) {
                 GroupOptionsButtonView(text: "Settle up", isForSettleUp: isSettleUpEnable, onTap: onSettleUpTap)
 
+                GroupOptionsButtonView(text: "Totals", onTap: onTotalsTap)
+
                 GroupOptionsButtonView(text: "Transactions", onTap: onTransactionsTap)
 
                 GroupOptionsButtonView(text: "Balances", onTap: onBalanceTap)
-
-                GroupOptionsButtonView(text: "Totals", onTap: onTotalsTap)
             }
             .padding(.bottom, 4)
             .padding(.vertical, 6)

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -97,11 +97,11 @@ struct GroupOptionsListView: View {
             HStack(spacing: 16) {
                 GroupOptionsButtonView(text: "Settle up", isForSettleUp: isSettleUpEnable, onTap: onSettleUpTap)
 
-                GroupOptionsButtonView(text: "Totals", onTap: onTotalsTap)
-
                 GroupOptionsButtonView(text: "Transactions", onTap: onTransactionsTap)
 
                 GroupOptionsButtonView(text: "Balances", onTap: onBalanceTap)
+
+                GroupOptionsButtonView(text: "Totals", onTap: onTotalsTap)
             }
             .padding(.bottom, 4)
             .padding(.vertical, 6)

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -37,8 +37,14 @@ struct GroupHomeView: View {
         .navigationBarTitle(viewModel.group?.name ?? "", displayMode: .inline)
         .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
         .fullScreenCover(isPresented: $viewModel.showSettleUpSheet) {
-            GroupSettleUpRouteView(appRoute: .init(root: .GroupSettleUpView(groupId: viewModel.group?.id ?? ""))) {
-                viewModel.showSettleUpSheet = false
+            if !(viewModel.memberOwingAmount.isEmpty) {
+                GroupSettleUpRouteView(appRoute: .init(root: .GroupSettleUpView(groupId: viewModel.group?.id ?? ""))) {
+                    viewModel.showSettleUpSheet = false
+                }
+            } else {
+                GroupSettleUpRouteView(appRoute: .init(root: .GroupWhoIsPayingView(groupId: viewModel.group?.id ?? "", memberOwingAmount: viewModel.memberOwingAmount))) {
+                    viewModel.showSettleUpSheet = false
+                }
             }
         }
         .fullScreenCover(isPresented: $viewModel.showTransactionsSheet) {
@@ -86,6 +92,7 @@ struct GroupHomeView: View {
 struct GroupOptionsListView: View {
 
     var isSettleUpEnable: Bool
+    let showTransactionsOption: Bool
 
     let onSettleUpTap: () -> Void
     let onTransactionsTap: () -> Void
@@ -97,7 +104,9 @@ struct GroupOptionsListView: View {
             HStack(spacing: 16) {
                 GroupOptionsButtonView(text: "Settle up", isForSettleUp: isSettleUpEnable, onTap: onSettleUpTap)
 
-                GroupOptionsButtonView(text: "Transactions", onTap: onTransactionsTap)
+                if showTransactionsOption {
+                    GroupOptionsButtonView(text: "Transactions", onTap: onTransactionsTap)
+                }
 
                 GroupOptionsButtonView(text: "Balances", onTap: onBalanceTap)
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -42,7 +42,7 @@ struct GroupHomeView: View {
                     viewModel.showSettleUpSheet = false
                 }
             } else {
-                GroupSettleUpRouteView(appRoute: .init(root: .GroupWhoIsPayingView(groupId: viewModel.group?.id ?? "", memberOwingAmount: viewModel.memberOwingAmount))) {
+                GroupSettleUpRouteView(appRoute: .init(root: .GroupWhoIsPayingView(groupId: viewModel.group?.id ?? "", isPaymentSettled: true))) {
                     viewModel.showSettleUpSheet = false
                 }
             }

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -13,6 +13,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     @Inject private var preference: SplitoPreference
     @Inject private var groupRepository: GroupRepository
     @Inject private var expenseRepository: ExpenseRepository
+    @Inject private var transactionRepository: TransactionRepository
 
     @Published private var expenses: [Expense] = []
     @Published var expensesWithUser: [ExpenseWithUser] = []
@@ -48,6 +49,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     private let groupId: String
     private let router: Router<AppRoute>
     private var groupUserData: [AppUser] = []
+    private var transactions: [Transactions] = []
     private let onGroupSelected: ((String?) -> Void)?
 
     init(router: Router<AppRoute>, groupId: String, onGroupSelected: ((String?) -> Void)?) {
@@ -76,6 +78,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                         self.groupUserData.append(memberData)
                     }
                 }
+                self.fetchTransactions()
                 self.fetchExpenses()
             }.store(in: &cancelable)
     }
@@ -98,6 +101,19 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
             }.store(in: &cancelable)
     }
 
+    func fetchTransactions() {
+        transactionRepository.fetchTransactionsBy(groupId: groupId).sink { [weak self] completion in
+            if case .failure(let error) = completion {
+                self?.groupState = .noMember
+                self?.showToastFor(error)
+            }
+        } receiveValue: { [weak self] transactions in
+            guard let self else { return }
+            print("xxx transactions: \(transactions)")
+            self.transactions = transactions
+        }.store(in: &cancelable)
+    }
+
     private func fetchExpenses() {
         expenseRepository.fetchExpensesBy(groupId: groupId)
             .sink { [weak self] completion in
@@ -108,6 +124,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] expenses in
                 guard let self, let group else { return }
                 self.expenses = expenses
+                print("xxx expenses: \(expenses)")
                 if group.isDebtSimplified {
                     self.calculateExpensesSimply()
                 } else {
@@ -164,7 +181,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     }
 
     private func calculateExpensesSimply() {
-        guard let userId = self.preference.user?.id else { return }
+        guard let userId = preference.user?.id else { return }
 
         let queue = DispatchGroup()
         var ownAmounts: [String: Double] = [:]
@@ -182,7 +199,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
             for member in expense.splitTo {
                 ownAmounts[member, default: 0.0] -= splitAmount
             }
-
             self.fetchUserData(for: expense.paidBy) { user in
                 combinedData.append(ExpenseWithUser(expense: expense, user: user))
                 queue.leave()
@@ -193,52 +209,50 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
             let debts = self.settleDebts(users: ownAmounts)
 
             for debt in debts where debt.0 == userId || debt.1 == userId {
-                self.overallOwingAmount += debt.1 == userId ? debt.2 : -debt.2
                 self.memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
             }
+            self.memberOwingAmount = self.memberOwingAmount.filter { $0.value != 0 }
 
+            for transaction in self.transactions {
+                let payer = transaction.payerId
+                let receiver = transaction.receiverId
+                let amount = transaction.amount
+
+                if payer == userId, let currentAmount = self.memberOwingAmount[receiver] {
+                    self.memberOwingAmount[receiver] = currentAmount + amount
+                } else if receiver == userId, let currentAmount = self.memberOwingAmount[payer] {
+                    self.memberOwingAmount[payer] = currentAmount - amount
+                }
+            }
+
+            self.memberOwingAmount = self.memberOwingAmount.filter { $0.value != 0 }
+            self.overallOwingAmount = self.memberOwingAmount.values.reduce(0, +)
             self.expensesWithUser = combinedData
             self.setGroupViewState()
         }
     }
 
     private func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
-        var creditors: [(String, Double)] = []
-        var debtors: [(String, Double)] = []
+        var mutableUsers = users
+        var debts: [(String, String, Double)] = []
+        let positiveAmounts = mutableUsers.filter { $0.value > 0 }
+        let negativeAmounts = mutableUsers.filter { $0.value < 0 }
 
-        // Separate users into creditors and debtors
-        for (user, balance) in users {
-            if balance > 0 {
-                creditors.append((user, balance))
-            } else if balance < 0 {
-                debtors.append((user, -balance)) // Store as positive for ease of calculation
+        for (creditor, creditAmount) in positiveAmounts {
+            var remainingCredit = creditAmount
+
+            for (debtor, debtAmount) in negativeAmounts {
+                if remainingCredit == 0 { break }
+                let amountToSettle = min(remainingCredit, -debtAmount)
+                if amountToSettle > 0 {
+                    debts.append((debtor, creditor, amountToSettle))
+                    remainingCredit -= amountToSettle
+                    mutableUsers[debtor]! += amountToSettle
+                    mutableUsers[creditor]! -= amountToSettle
+                }
             }
         }
-
-        // Sort creditors and debtors by the amount they owe or are owed
-        creditors.sort { $0.1 < $1.1 }
-        debtors.sort { $0.1 < $1.1 }
-
-        var transactions: [(String, String, Double)] = [] // (debtor, creditor, amount)
-        var cIdx = 0
-        var dIdx = 0
-
-        while cIdx < creditors.count && dIdx < debtors.count { // Process all debts
-            let (creditor, credAmt) = creditors[cIdx]
-            let (debtor, debtAmt) = debtors[dIdx]
-            let minAmt = min(credAmt, debtAmt)
-
-            transactions.append((debtor, creditor, minAmt)) // Record the transaction
-
-            // Update the amounts
-            creditors[cIdx] = (creditor, credAmt - minAmt)
-            debtors[dIdx] = (debtor, debtAmt - minAmt)
-
-            // Move the index forward if someone's balance is settled
-            if creditors[cIdx].1 == 0 { cIdx += 1 }
-            if debtors[dIdx].1 == 0 { dIdx += 1 }
-        }
-        return transactions
+        return debts
     }
 
     private func fetchUserData(for userId: String, completion: @escaping (AppUser) -> Void) {

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -107,7 +107,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 if case .failure(let error) = completion {
                     guard let self else { return }
                     self.showToastFor(error)
-                    self.fetchExpenses()
                 }
             } receiveValue: { [weak self] transactions in
                 guard let self else { return }

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -185,11 +185,11 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         }
 
         queue.notify(queue: .main) { [self] in
-            owesToUser.forEach { payerId, amount in
-                memberOwingAmount[payerId, default: 0.0] += amount
+            owesToUser.forEach { payerId, owesAmount in
+                memberOwingAmount[payerId, default: 0.0] += owesAmount
             }
-            owedByUser.forEach { receiverId, amount in
-                memberOwingAmount[receiverId, default: 0.0] -= amount
+            owedByUser.forEach { receiverId, owedAmount in
+                memberOwingAmount[receiverId, default: 0.0] -= owedAmount
             }
 
             self.expensesWithUser = combinedData

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -57,7 +57,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         self.groupId = groupId
         self.onGroupSelected = onGroupSelected
         super.init()
-        self.fetchLatestTransactions()
+        self.fetchLatestExpenses()
 
         self.onGroupSelected?(groupId)
     }
@@ -72,11 +72,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
             } receiveValue: { [weak self] expenses in
                 guard let self, let group else { return }
                 self.expenses = expenses
-                if group.isDebtSimplified {
-                    self.calculateExpensesSimply()
-                } else {
-                    self.calculateExpenses()
-                }
+                self.fetchLatestTransactions()
             }.store(in: &cancelable)
     }
 
@@ -87,9 +83,13 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                     self?.showToastFor(error)
                 }
             } receiveValue: { [weak self] transactions in
-                guard let self else { return }
+                guard let self, let group else { return }
                 self.transactions = transactions
-                self.fetchExpenses()
+                if group.isDebtSimplified {
+                    self.calculateExpensesSimply()
+                } else {
+                    self.calculateExpenses()
+                }
             }.store(in: &cancelable)
     }
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -211,14 +211,14 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         }
 
         queue.notify(queue: .main) { [self] in
-            let owingAmount = processTransactionsSimply(userId: userId, transactions: transactions, memberOwingAmount: memberOwingAmount)
-            memberOwingAmount = owingAmount.filter { $0.value != 0 }
-
             let debts = settleDebts(users: ownAmounts)
             for debt in debts where debt.0 == userId || debt.1 == userId {
                 self.memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
             }
 
+            let owingAmount = processTransactionsSimply(userId: userId, transactions: transactions, memberOwingAmount: memberOwingAmount)
+
+            memberOwingAmount = owingAmount.filter { $0.value != 0 }
             overallOwingAmount = memberOwingAmount.values.reduce(0, +)
             expensesWithUser = combinedData
             setGroupViewState()

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -251,26 +251,42 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     }
 
     private func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
-        var mutableUsers = users
-        var debts: [(String, String, Double)] = []
-        let positiveAmounts = mutableUsers.filter { $0.value > 0 }
-        let negativeAmounts = mutableUsers.filter { $0.value < 0 }
+        var creditors: [(String, Double)] = []
+        var debtors: [(String, Double)] = []
 
-        for (creditor, creditAmount) in positiveAmounts {
-            var remainingCredit = creditAmount
-
-            for (debtor, debtAmount) in negativeAmounts {
-                if remainingCredit == 0 { break }
-                let amountToSettle = min(remainingCredit, -debtAmount)
-                if amountToSettle > 0 {
-                    debts.append((debtor, creditor, amountToSettle))
-                    remainingCredit -= amountToSettle
-                    mutableUsers[debtor]! += amountToSettle
-                    mutableUsers[creditor]! -= amountToSettle
-                }
+        // Separate users into creditors and debtors
+        for (user, balance) in users {
+            if balance > 0 {
+                creditors.append((user, balance))
+            } else if balance < 0 {
+                debtors.append((user, -balance)) // Store as positive for ease of calculation
             }
         }
-        return debts
+
+        // Sort creditors and debtors by the amount they owe or are owed
+        creditors.sort { $0.1 < $1.1 }
+        debtors.sort { $0.1 < $1.1 }
+
+        var transactions: [(String, String, Double)] = [] // (debtor, creditor, amount)
+        var cIdx = 0
+        var dIdx = 0
+
+        while cIdx < creditors.count && dIdx < debtors.count { // Process all debts
+            let (creditor, credAmt) = creditors[cIdx]
+            let (debtor, debtAmt) = debtors[dIdx]
+            let minAmt = min(credAmt, debtAmt)
+
+            transactions.append((debtor, creditor, minAmt)) // Record the transaction
+
+            // Update the amounts
+            creditors[cIdx] = (creditor, credAmt - minAmt)
+            debtors[dIdx] = (debtor, debtAmt - minAmt)
+
+            // Move the index forward if someone's balance is settled
+            if creditors[cIdx].1 == 0 { cIdx += 1 }
+            if debtors[dIdx].1 == 0 { dIdx += 1 }
+        }
+        return transactions
     }
 
     private func fetchUserData(for userId: String, completion: @escaping (AppUser) -> Void) {

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -88,7 +88,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                     self?.showToastFor(error)
                 }
             } receiveValue: { [weak self] expenses in
-                guard let self, let group, !self.expenses.isEmpty else { return }
+                guard let self, let group else { return }
                 self.expenses = expenses
                 if group.isDebtSimplified {
                     self.calculateExpensesSimply()

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -62,6 +62,19 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         self.onGroupSelected?(groupId)
     }
 
+    private func fetchLatestTransactions() {
+        transactionRepository.fetchLatestTransactionsBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.showToastFor(error)
+                }
+            } receiveValue: { [weak self] transactions in
+                guard let self else { return }
+                self.transactions = transactions
+                self.fetchLatestExpenses()
+            }.store(in: &cancelable)
+    }
+
     private func fetchLatestExpenses() {
         expenseRepository.fetchLatestExpensesBy(groupId: groupId)
             .sink { [weak self] completion in
@@ -77,19 +90,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 } else {
                     self.calculateExpenses()
                 }
-            }.store(in: &cancelable)
-    }
-
-    private func fetchLatestTransactions() {
-        transactionRepository.fetchLatestTransactionsBy(groupId: groupId)
-            .sink { [weak self] completion in
-                if case .failure(let error) = completion {
-                    self?.showToastFor(error)
-                }
-            } receiveValue: { [weak self] transactions in
-                guard let self else { return }
-                self.transactions = transactions
-                self.fetchLatestExpenses()
             }.store(in: &cancelable)
     }
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -154,7 +154,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         overallOwingAmount = 0.0
         memberOwingAmount = [:]
 
-        // Process each expense to calculate the amounts owed by and to the user
         for expense in expenses {
             queue.enter()
 
@@ -176,7 +175,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         }
 
         queue.notify(queue: .main) { [self] in
-            // Process the transactions to update the owesToUser and owedByUser
             let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, owesToUser: owesToUser, owedByUser: owedByUser)
 
             withAnimation(.easeOut) {
@@ -197,7 +195,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
 
         overallOwingAmount = 0.0
 
-        // Process each expense to calculate net amounts for each user
         for expense in expenses {
             queue.enter()
 
@@ -213,7 +210,6 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         }
 
         queue.notify(queue: .main) { [self] in
-            // Process the transactions and settle debts
             let memberOwingAmount = processTransactionsSimply(userId: userId, transactions: transactions, ownAmounts: ownAmounts)
 
             withAnimation(.easeOut) {

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -57,7 +57,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         self.groupId = groupId
         self.onGroupSelected = onGroupSelected
         super.init()
-        self.fetchLatestExpenses()
+        self.fetchLatestTransactions()
 
         self.onGroupSelected?(groupId)
     }
@@ -98,6 +98,21 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 } else {
                     self.calculateExpenses()
                 }
+            }.store(in: &cancelable)
+    }
+
+    private func fetchLatestTransactions() {
+        transactionRepository.fetchLatestTransactionsBy(groupId: groupId)
+            .sink { [weak self] completion in
+                if case .failure(let error) = completion {
+                    guard let self else { return }
+                    self.showToastFor(error)
+                    self.fetchExpenses()
+                }
+            } receiveValue: { [weak self] transactions in
+                guard let self else { return }
+                self.transactions = transactions
+                self.fetchExpenses()
             }.store(in: &cancelable)
     }
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -181,8 +181,8 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 self.memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
                 expensesWithUser = combinedData
                 overallOwingAmount = memberOwingAmount.values.reduce(0, +)
-                setGroupViewState()
             }
+            setGroupViewState()
         }
     }
 
@@ -216,8 +216,8 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 self.memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
                 overallOwingAmount = self.memberOwingAmount.values.reduce(0, +)
                 expensesWithUser = combinedData
-                setGroupViewState()
             }
+            setGroupViewState()
         }
     }
 

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -175,12 +175,12 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
         }
 
         queue.notify(queue: .main) { [self] in
-            let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, owesToUser: owesToUser, owedByUser: owedByUser)
+            let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, owesToUser: owesToUser, owedByUser: owedByUser, isSimplify: false)
 
             withAnimation(.easeOut) {
                 self.memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
-                expensesWithUser = combinedData
                 overallOwingAmount = memberOwingAmount.values.reduce(0, +)
+                expensesWithUser = combinedData
             }
             setGroupViewState()
         }
@@ -216,11 +216,13 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
                 self.memberOwingAmount[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
             }
 
-            let owingAmount = processTransactionsSimply(userId: userId, transactions: transactions, memberOwingAmount: memberOwingAmount)
+            let memberOwingAmount = processTransactions(userId: userId, transactions: transactions, ownAmounts: memberOwingAmount, isSimplify: true)
 
-            memberOwingAmount = owingAmount.filter { $0.value != 0 }
-            overallOwingAmount = memberOwingAmount.values.reduce(0, +)
-            expensesWithUser = combinedData
+            withAnimation(.easeOut) {
+                self.memberOwingAmount = memberOwingAmount.filter { $0.value != 0 }
+                overallOwingAmount = memberOwingAmount.values.reduce(0, +)
+                expensesWithUser = combinedData
+            }
             setGroupViewState()
         }
     }

--- a/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
@@ -8,6 +8,7 @@
 import Data
 import Combine
 import BaseStyle
+import SwiftUI
 
 class GroupSettingViewModel: BaseViewModel, ObservableObject {
 
@@ -191,7 +192,7 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
     }
 
     private func showRemoveMemberAlert(memberId: String) {
-        guard amountOweByMember[memberId] == 0 else {
+        guard amountOweByMember[memberId] == 0 || amountOweByMember[memberId] == nil else {
             memberRemoveType = .remove
             showDebtOutstandingAlert(memberId: memberId)
             return
@@ -248,6 +249,11 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
                     self.goBackToGroupList()
                 } else {
                     self.showAlert = false
+                    withAnimation {
+                        if let index = self.members.firstIndex(where: { $0.id == memberId }) {
+                            self.members.remove(at: index)
+                        }
+                    }
                     self.showToastFor(toast: ToastPrompt(type: .success, title: "Success", message: "Group member removed"))
                 }
             }.store(in: &cancelable)

--- a/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
@@ -113,28 +113,11 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
                 }
             } receiveValue: { [weak self] expenses in
                 guard let self else { return }
-                self.calculateExpenses(expenses: expenses)
+                self.amountOweByMember = calculateSettingsExpenses(expenses: expenses, transactions: transactions)
+                DispatchQueue.main.async {
+                    self.currentViewState = .initial
+                }
             }.store(in: &cancelable)
-    }
-
-    private func calculateExpenses(expenses: [Expense]) {
-        for expense in expenses {
-            self.amountOweByMember[expense.paidBy, default: 0.0] += expense.amount
-
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-            for member in expense.splitTo {
-                self.amountOweByMember[member, default: 0.0] -= splitAmount
-            }
-        }
-
-        for transaction in transactions {
-            self.amountOweByMember[transaction.payerId, default: 0.0] += transaction.amount
-            self.amountOweByMember[transaction.receiverId, default: 0.0] -= transaction.amount
-        }
-
-        DispatchQueue.main.async {
-            self.currentViewState = .initial
-        }
     }
 
     private func checkForGroupAdmin() {

--- a/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
@@ -16,20 +16,15 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
     @Inject private var expenseRepository: ExpenseRepository
     @Inject private var transactionRepository: TransactionRepository
 
-    private let groupId: String
-    private let router: Router<AppRoute>
-    private var memberRemoveType: MemberRemoveType = .leave
-
-    @Published var isAdmin = false
+    @Published private(set) var isAdmin = false
     @Published var showLeaveGroupDialog = false
     @Published var showRemoveMemberDialog = false
 
-    @Published var groupTotalExpense = 0.0
-    @Published var amountOweByMember: [String: Double] = [:]
+    @Published private(set) var group: Groups?
+    @Published private(set) var members: [AppUser] = []
+    @Published private(set) var amountOweByMember: [String: Double] = [:]
 
-    @Published var group: Groups?
-    @Published var members: [AppUser] = []
-    @Published var currentViewState: ViewState = .loading
+    @Published private(set) var currentViewState: ViewState = .loading
 
     @Published var isDebtSimplified = false {
         didSet {
@@ -37,7 +32,10 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
         }
     }
 
+    private let groupId: String
+    private let router: Router<AppRoute>
     private var transactions: [Transactions] = []
+    private var memberRemoveType: MemberRemoveType = .leave
 
     init(router: Router<AppRoute>, groupId: String) {
         self.router = router
@@ -103,7 +101,6 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
         } receiveValue: { [weak self] transactions in
             guard let self else { return }
             self.transactions = transactions
-            print("xxx \(transactions)")
         }.store(in: &cancelable)
     }
 

--- a/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingViewModel.swift
@@ -113,7 +113,7 @@ class GroupSettingViewModel: BaseViewModel, ObservableObject {
                 }
             } receiveValue: { [weak self] expenses in
                 guard let self else { return }
-                self.amountOweByMember = calculateSettingsExpenses(expenses: expenses, transactions: transactions)
+                self.amountOweByMember = calculateTransactionsWithExpenses(expenses: expenses, transactions: transactions)
                 DispatchQueue.main.async {
                     self.currentViewState = .initial
                 }

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -163,16 +163,14 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
         guard let userId = self.preference.user?.id else { return Fail(error: .dataNotFound).eraseToAnyPublisher() }
 
         let memberOwingAmount = calculateExpensesNonSimplify(userId: userId, expenses: expenses, transactions: transactions)
-
         return Just((memberOwingAmount.values.reduce(0, +), memberOwingAmount)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
     }
 
     private func calculateExpensesSimply(expenses: [Expense], transactions: [Transactions]) -> AnyPublisher<(Double, [String: Double]), ServiceError> {
         guard let userId = self.preference.user?.id else { return Fail(error: .dataNotFound).eraseToAnyPublisher() }
 
-        let oweByUser = calculateExpensesSimplify(userId: userId, expenses: expenses, transactions: transactions)
-
-        return Just((oweByUser.values.reduce(0, +), oweByUser)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
+        let memberOwingAmount = calculateExpensesSimplify(userId: userId, expenses: expenses, transactions: transactions)
+        return Just((memberOwingAmount.values.reduce(0, +), memberOwingAmount)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
     }
 }
 

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -127,22 +127,6 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
         groupRepository.fetchMembersBy(groupId: groupId)
     }
 
-    private func fetchTransactions(groupId: String?) -> [Transactions] {
-        var transactionsData: [Transactions] = []
-        guard let groupId else { return transactionsData }
-
-        transactionRepository.fetchTransactionsBy(groupId: groupId).sink { [weak self] completion in
-            if case .failure(let error) = completion {
-                self?.currentViewState = .initial
-                self?.showToastFor(error)
-            }
-        } receiveValue: { transactions in
-            transactionsData = transactions
-        }.store(in: &cancelable)
-
-        return transactionsData
-    }
-
     private func fetchExpenses(group: Groups) -> AnyPublisher<(Double, [String: Double], Bool), ServiceError> {
         guard let groupId = group.id else {
             return Fail(error: ServiceError.dataNotFound).eraseToAnyPublisher()
@@ -222,7 +206,6 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
         owedByUser.forEach { userId, owedAmount in
             ownAmount[userId] = (ownAmount[userId] ?? 0) - owedAmount
         }
-
         expenseByUser = ownAmount.values.reduce(0, +)
 
         return Just((expenseByUser, ownAmount)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -134,8 +134,6 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
 
         let expensesPublisher = expenseRepository.fetchExpensesBy(groupId: groupId)
         let transactionsPublisher = transactionRepository.fetchTransactionsBy(groupId: groupId)
-            .mapError { _ in ServiceError.dataNotFound }
-            .catch { _ in Just([]).setFailureType(to: ServiceError.self) }
 
         return expensesPublisher
             .combineLatest(transactionsPublisher)

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -269,42 +269,27 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
     }
 
     private func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
-        var creditors: [(String, Double)] = []
-        var debtors: [(String, Double)] = []
+        var mutableUsers = users
+        var debts: [(String, String, Double)] = []
+        let positiveAmounts = mutableUsers.filter { $0.value > 0 }
+        let negativeAmounts = mutableUsers.filter { $0.value < 0 }
 
-        // Separate users into creditors and debtors
-        for (user, balance) in users {
-            if balance > 0 {
-                creditors.append((user, balance))
-            } else if balance < 0 {
-                debtors.append((user, -balance)) // Store as positive for ease of calculation
+        for (creditor, creditAmount) in positiveAmounts {
+            var remainingCredit = creditAmount
+
+            for (debtor, debtAmount) in negativeAmounts {
+                if remainingCredit == 0 { break }
+                let amountToSettle = min(remainingCredit, -debtAmount)
+                if amountToSettle > 0 {
+                    debts.append((debtor, creditor, amountToSettle))
+                    remainingCredit -= amountToSettle
+                    mutableUsers[debtor]! += amountToSettle
+                    mutableUsers[creditor]! -= amountToSettle
+                }
             }
         }
 
-        // Sort creditors and debtors by the amount they owe or are owed
-        creditors.sort { $0.1 < $1.1 }
-        debtors.sort { $0.1 < $1.1 }
-
-        var transactions: [(String, String, Double)] = [] // (debtor, creditor, amount)
-        var cIdx = 0
-        var dIdx = 0
-
-        while cIdx < creditors.count && dIdx < debtors.count { // Process all debts
-            let (creditor, credAmt) = creditors[cIdx]
-            let (debtor, debtAmt) = debtors[dIdx]
-            let minAmt = min(credAmt, debtAmt)
-
-            transactions.append((debtor, creditor, minAmt)) // Record the transaction
-
-            // Update the amounts
-            creditors[cIdx] = (creditor, credAmt - minAmt)
-            debtors[dIdx] = (debtor, debtAmt - minAmt)
-
-            // Move the index forward if someone's balance is settled
-            if creditors[cIdx].1 == 0 { cIdx += 1 }
-            if debtors[dIdx].1 == 0 { dIdx += 1 }
-        }
-        return transactions
+        return debts
     }
 }
 

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -162,117 +162,17 @@ class GroupListViewModel: BaseViewModel, ObservableObject {
     private func calculateExpenses(expenses: [Expense], transactions: [Transactions]) -> AnyPublisher<(Double, [String: Double]), ServiceError> {
         guard let userId = self.preference.user?.id else { return Fail(error: .dataNotFound).eraseToAnyPublisher() }
 
-        var expenseByUser = 0.0
-        var owesToUser: [String: Double] = [:]
-        var owedByUser: [String: Double] = [:]
-        var ownAmount: [String: Double] = [:]
+        let memberOwingAmount = calculateExpensesNonSimplify(userId: userId, expenses: expenses, transactions: transactions)
 
-        for expense in expenses {
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-            if expense.paidBy == userId {
-                expenseByUser += expense.splitTo.contains(userId) ? expense.amount - splitAmount : expense.amount
-                for member in expense.splitTo where member != userId {
-                    owesToUser[member, default: 0.0] += splitAmount
-                }
-            } else if expense.splitTo.contains(where: { $0 == userId }) {
-                expenseByUser -= splitAmount
-                owedByUser[expense.paidBy, default: 0.0] += splitAmount
-            }
-        }
-
-        for transaction in transactions {
-            let payer = transaction.payerId
-            let receiver = transaction.receiverId
-            let amount = transaction.amount
-
-            if transaction.payerId == userId {
-                if owedByUser[receiver] != nil {
-                    owesToUser[transaction.receiverId, default: 0.0] += amount
-                } else {
-                    owedByUser[transaction.payerId, default: 0.0] -= amount
-                }
-            } else if transaction.receiverId == userId {
-                if owesToUser[payer] != nil {
-                    owedByUser[transaction.payerId, default: 0.0] += amount
-                } else {
-                    owesToUser[payer] = -amount
-                }
-            }
-        }
-
-        owesToUser.forEach { userId, owesAmount in
-            ownAmount[userId] = owesAmount
-        }
-        owedByUser.forEach { userId, owedAmount in
-            ownAmount[userId] = (ownAmount[userId] ?? 0) - owedAmount
-        }
-        expenseByUser = ownAmount.values.reduce(0, +)
-
-        return Just((expenseByUser, ownAmount)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
+        return Just((memberOwingAmount.values.reduce(0, +), memberOwingAmount)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
     }
 
     private func calculateExpensesSimply(expenses: [Expense], transactions: [Transactions]) -> AnyPublisher<(Double, [String: Double]), ServiceError> {
         guard let userId = self.preference.user?.id else { return Fail(error: .dataNotFound).eraseToAnyPublisher() }
 
-        var expenseByUser = 0.0
-        var ownAmount: [String: Double] = [:]
+        let oweByUser = calculateExpensesSimplify(userId: userId, expenses: expenses, transactions: transactions)
 
-        for expense in expenses {
-            ownAmount[expense.paidBy, default: 0.0] += expense.amount
-            let splitAmount = expense.amount / Double(expense.splitTo.count)
-
-            for member in expense.splitTo {
-                ownAmount[member, default: 0.0] -= splitAmount
-            }
-        }
-
-        var oweByUser: [String: Double] = [:]
-        let debts = settleDebts(users: ownAmount)
-
-        for debt in debts where debt.0 == userId || debt.1 == userId {
-            expenseByUser += debt.1 == userId ? debt.2 : -debt.2
-            oweByUser[debt.1 == userId ? debt.0 : debt.1] = debt.1 == userId ? debt.2 : -debt.2
-        }
-
-        for transaction in transactions {
-            let payer = transaction.payerId
-            let receiver = transaction.receiverId
-            let amount = transaction.amount
-
-            if payer == userId, let currentAmount = oweByUser[receiver] {
-                oweByUser[receiver] = currentAmount + amount
-            } else if receiver == userId, let currentAmount = oweByUser[payer] {
-                oweByUser[payer] = currentAmount - amount
-            }
-        }
-
-        expenseByUser = oweByUser.values.reduce(0, +)
-
-        return Just((expenseByUser, oweByUser)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
-    }
-
-    private func settleDebts(users: [String: Double]) -> [(String, String, Double)] {
-        var mutableUsers = users
-        var debts: [(String, String, Double)] = []
-        let positiveAmounts = mutableUsers.filter { $0.value > 0 }
-        let negativeAmounts = mutableUsers.filter { $0.value < 0 }
-
-        for (creditor, creditAmount) in positiveAmounts {
-            var remainingCredit = creditAmount
-
-            for (debtor, debtAmount) in negativeAmounts {
-                if remainingCredit == 0 { break }
-                let amountToSettle = min(remainingCredit, -debtAmount)
-                if amountToSettle > 0 {
-                    debts.append((debtor, creditor, amountToSettle))
-                    remainingCredit -= amountToSettle
-                    mutableUsers[debtor]! += amountToSettle
-                    mutableUsers[creditor]! -= amountToSettle
-                }
-            }
-        }
-
-        return debts
+        return Just((oweByUser.values.reduce(0, +), oweByUser)).setFailureType(to: ServiceError.self).eraseToAnyPublisher()
     }
 }
 

--- a/Splito/UI/Login/LoginViewModel.swift
+++ b/Splito/UI/Login/LoginViewModel.swift
@@ -6,24 +6,22 @@
 //
 
 import Data
-import Combine
-import BaseStyle
 import GoogleSignIn
 import FirebaseCore
 import FirebaseAuth
 import AuthenticationServices
+import BaseStyle
 
 public class LoginViewModel: BaseViewModel, ObservableObject {
 
+    @Inject private var preference: SplitoPreference
+    @Inject private var userRepository: UserRepository
+    
     @Published private(set) var showGoogleLoading = false
     @Published private(set) var showAppleLoading = false
 
-    @Inject private var preference: SplitoPreference
-    @Inject private var userRepository: UserRepository
-
     private var currentNonce: String = ""
     private var appleSignInDelegates: SignInWithAppleDelegates! = nil
-
     private let router: Router<AppRoute>
 
     init(router: Router<AppRoute>) {

--- a/Splito/UI/Login/LoginViewModel.swift
+++ b/Splito/UI/Login/LoginViewModel.swift
@@ -16,7 +16,7 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
 
     @Inject private var preference: SplitoPreference
     @Inject private var userRepository: UserRepository
-    
+
     @Published private(set) var showGoogleLoading = false
     @Published private(set) var showAppleLoading = false
 

--- a/Splito/UI/Login/LoginViewModel.swift
+++ b/Splito/UI/Login/LoginViewModel.swift
@@ -111,7 +111,7 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
 					self.alert = .init(message: error.localizedDescription)
 					self.showAlert = true
 				}
-            } receiveValue: { [weak self] _ in
+            } receiveValue: { [weak self] user in
                 guard let self else { return }
 				self.preference.user = user
                 self.onLoginSuccess()


### PR DESCRIPTION
- [x] Settle up owing amount with payment in group list, group home and settle up, balances, totals screen 
- [x] Show payments made & received data in totals sheet's group spending summary 
- [x] Fix: profile image not getting issue after sign in with google and apple id 
- [x] Manage settle up option color and it's flow when all expenses are settled up
- [x] Fix transaction info text in the transaction detail screen
- [x] Hide transaction option when there are no transactions made in group
- [x] If there is no expenses with member or member is settled up then after not able to remove member

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced transaction processing and expense calculation functions for settling debts and managing user transactions.
	- Added functionality to fetch and process transactions within group balances and home view models.
- **Improvements**
	- Enhanced expense calculation methods to include transaction data, improving accuracy in debt settlement.
	- Updated data handling in group balances and home view models for better encapsulation and data integrity.
	- Improved dependency injection for better testability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->