### PR TITLE
Add fixed amounts split expense option type

### DIFF
--- a/Data/Data/Model/Expense.swift
+++ b/Data/Data/Model/Expense.swift
@@ -55,17 +55,20 @@ public struct Expense: Codable, Hashable {
 
 public enum SplitType: String, Codable, CaseIterable {
     case equally
+    case fixedAmount
     case percentage
     case shares
 
-    public var image: String {
+    public var tabIcon: String {
         switch self {
         case .equally:
-            return "equal"
+            return "="
+        case .fixedAmount:
+            return "1.23"
         case .percentage:
-            return "percent"
+            return "%"
         case .shares:
-            return "blinds.vertical.open"
+            return "|||"
         }
     }
 }

--- a/Splito/UI/Home/Expense/AddExpenseView.swift
+++ b/Splito/UI/Home/Expense/AddExpenseView.swift
@@ -62,10 +62,10 @@ struct AddExpenseView: View {
                 ExpenseSplitOptionsView(
                     viewModel: ExpenseSplitOptionsViewModel(amount: viewModel.expenseAmount,
                                                             splitType: viewModel.splitType,
-                                                            splitData: viewModel.splitType == .percentage ? viewModel.percentages : viewModel.shares,
+                                                            splitData: viewModel.splitData,
                                                             members: viewModel.groupMembers,
                                                             selectedMembers: viewModel.selectedMembers,
-                                                            handleSplitTypeSelection: viewModel.handleSplitTypeSelection(members:percentages:shares:splitType:))
+                                                            handleSplitTypeSelection: viewModel.handleSplitTypeSelection(members:splitData:splitType:))
                 )
             }
         }

--- a/Splito/UI/Home/Expense/AddExpenseViewModel.swift
+++ b/Splito/UI/Home/Expense/AddExpenseViewModel.swift
@@ -30,8 +30,7 @@ class AddExpenseViewModel: BaseViewModel, ObservableObject {
 
     @Published private(set) var expense: Expense?
     @Published private(set) var selectedGroup: Groups?
-    @Published private(set) var shares: [String: Double] = [:]
-    @Published private(set) var percentages: [String: Double] = [:]
+    @Published private(set) var splitData: [String: Double] = [:]
 
     @Published private(set) var groupMembers: [String] = []
     @Published private(set) var selectedMembers: [String] = []
@@ -110,11 +109,7 @@ class AddExpenseViewModel: BaseViewModel, ObservableObject {
                 self.splitType = expense.splitType
 
                 if let splitData = expense.splitData {
-                    if expense.splitType == .percentage {
-                        self.percentages = splitData
-                    } else if expense.splitType == .shares {
-                        self.shares = splitData
-                    }
+                    self.splitData = splitData
                 }
                 self.selectedMembers = expense.splitTo
 
@@ -206,10 +201,9 @@ extension AddExpenseViewModel {
         showSplitTypeSelection = true
     }
 
-    func handleSplitTypeSelection(members: [String], percentages: [String: Double], shares: [String: Double], splitType: SplitType) {
+    func handleSplitTypeSelection(members: [String], splitData: [String: Double], splitType: SplitType) {
         selectedMembers = members
-        self.percentages = percentages
-        self.shares = shares
+        self.splitData = splitData
         self.splitType = splitType
     }
 
@@ -232,14 +226,15 @@ extension AddExpenseViewModel {
             newExpense.date = Timestamp(date: expenseDate)
             newExpense.paidBy = selectedPayer.id
             newExpense.splitType = splitType
-            newExpense.splitTo = splitType == .percentage ? percentages.map({ $0.key }) : splitType == .shares ? shares.map({ $0.key }) : selectedMembers
-            newExpense.splitData = splitType == .percentage ? percentages : shares
+            newExpense.splitTo = (splitType == .percentage || splitType == .shares) ? splitData.map({ $0.key }) : selectedMembers
+            newExpense.splitData = splitData
 
             updateExpense(expense: newExpense)
         } else {
             let expense = Expense(name: expenseName.trimming(spaces: .leadingAndTrailing).capitalized, amount: expenseAmount,
-                                  date: Timestamp(date: expenseDate), paidBy: selectedPayer.id, addedBy: user.id, splitTo: selectedMembers,
-                                  groupId: groupId, splitType: splitType, splitData: splitType == .percentage ? percentages : shares)
+                                  date: Timestamp(date: expenseDate), paidBy: selectedPayer.id, addedBy: user.id,
+                                  splitTo: (splitType == .percentage || splitType == .shares) ? splitData.map({ $0.key }) : selectedMembers,
+                                  groupId: groupId, splitType: splitType, splitData: splitData)
 
             addExpense(expense: expense, completion: completion)
         }

--- a/Splito/UI/Home/Expense/AddExpenseViewModel.swift
+++ b/Splito/UI/Home/Expense/AddExpenseViewModel.swift
@@ -226,14 +226,14 @@ extension AddExpenseViewModel {
             newExpense.date = Timestamp(date: expenseDate)
             newExpense.paidBy = selectedPayer.id
             newExpense.splitType = splitType
-            newExpense.splitTo = (splitType == .percentage || splitType == .shares) ? splitData.map({ $0.key }) : selectedMembers
+            newExpense.splitTo = (splitType == .equally) ? selectedMembers : splitData.map({ $0.key })
             newExpense.splitData = splitData
 
             updateExpense(expense: newExpense)
         } else {
             let expense = Expense(name: expenseName.trimming(spaces: .leadingAndTrailing).capitalized, amount: expenseAmount,
                                   date: Timestamp(date: expenseDate), paidBy: selectedPayer.id, addedBy: user.id,
-                                  splitTo: (splitType == .percentage || splitType == .shares) ? splitData.map({ $0.key }) : selectedMembers,
+                                  splitTo: (splitType == .equally) ? selectedMembers : splitData.map({ $0.key }),
                                   groupId: groupId, splitType: splitType, splitData: splitData)
 
             addExpense(expense: expense, completion: completion)

--- a/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsTabView.swift
+++ b/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsTabView.swift
@@ -106,7 +106,7 @@ private struct FixedAmountView: View {
                         get: { viewModel.fixedAmounts[member.id] ?? 0 },
                         set: { viewModel.updateFixedAmount(for: member.id, amount: $0) }
                     ),
-                    member: member, suffixText: "",
+                    member: member, suffixText: "₹",
                     expenseAmount: viewModel.totalAmount,
                     onChange: { amount in
                         viewModel.updateFixedAmount(for: member.id, amount: amount)

--- a/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
+++ b/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
@@ -30,6 +30,8 @@ struct ExpenseSplitOptionsView: View {
                             switch viewModel.selectedTab {
                             case .equally:
                                 SplitOptionsTopView(title: "Split equally", subtitle: "Select which people owe an equal share.")
+                            case .fixedAmount:
+                                SplitOptionsTopView(title: "Split by exact amounts", subtitle: "Specify exactly how much each person owes.")
                             case .percentage:
                                 SplitOptionsTopView(title: "Split by percentages", subtitle: "Enter the percentage split that's fair for your situation.")
                             case .shares:
@@ -99,6 +101,9 @@ private struct SplitOptionsBottomView: View {
         case .equally:
             ExpenseSplitAmountView(memberCount: viewModel.selectedMembers.count, splitAmount: viewModel.splitAmount,
                                    isAllSelected: viewModel.isAllSelected, onAllBtnTap: viewModel.handleAllBtnAction)
+        case .fixedAmount:
+            BottomInfoCardView(title: "\(String(format: "%.0f", viewModel.totalFixedAmount)) of \(viewModel.totalAmount)",
+                               value: "\(String(format: "%.0f", (viewModel.totalAmount - viewModel.totalFixedAmount))) left")
         case .percentage:
             BottomInfoCardView(title: "\(String(format: "%.0f", viewModel.totalPercentage))% of 100%",
                                value: "\(String(format: "%.0f", 100 - viewModel.totalPercentage))% left")
@@ -207,5 +212,5 @@ private struct BottomInfoCardView: View {
 }
 
 #Preview {
-    ExpenseSplitOptionsView(viewModel: ExpenseSplitOptionsViewModel(amount: 0, members: [], selectedMembers: [], handleSplitTypeSelection: { _, _, _, _   in }))
+    ExpenseSplitOptionsView(viewModel: ExpenseSplitOptionsViewModel(amount: 0, members: [], selectedMembers: [], handleSplitTypeSelection: {_, _, _ in }))
 }

--- a/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
+++ b/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
@@ -102,8 +102,8 @@ private struct SplitOptionsBottomView: View {
             ExpenseSplitAmountView(memberCount: viewModel.selectedMembers.count, splitAmount: viewModel.splitAmount,
                                    isAllSelected: viewModel.isAllSelected, onAllBtnTap: viewModel.handleAllBtnAction)
         case .fixedAmount:
-            BottomInfoCardView(title: "\(String(format: "%.0f", viewModel.totalFixedAmount)) of \(viewModel.totalAmount)",
-                               value: "\(String(format: "%.0f", (viewModel.totalAmount - viewModel.totalFixedAmount))) left")
+            BottomInfoCardView(title: "₹ \(String(format: "%.0f", viewModel.totalFixedAmount)) of ₹ \(viewModel.totalAmount)",
+                               value: "₹ \(String(format: "%.0f", (viewModel.totalAmount - viewModel.totalFixedAmount))) left")
         case .percentage:
             BottomInfoCardView(title: "\(String(format: "%.0f", viewModel.totalPercentage))% of 100%",
                                value: "\(String(format: "%.0f", 100 - viewModel.totalPercentage))% left")

--- a/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
+++ b/Splito/UI/Home/Groups/CalculateExpensesFunctions.swift
@@ -161,6 +161,8 @@ public func calculateSplitAmount(member: String, expense: Expense) -> Double {
     switch expense.splitType {
     case .equally:
         splitAmount = expense.amount / Double(expense.splitTo.count)
+    case .fixedAmount:
+        splitAmount = expense.splitData?[member] ?? 0.0
     case .percentage:
         let totalPercentage = expense.splitData?.values.reduce(0, +) ?? 0.0
         splitAmount = expense.amount * (expense.splitData?[member] ?? 0.0) / totalPercentage

--- a/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Balances/GroupBalancesViewModel.swift
@@ -121,6 +121,12 @@ class GroupBalancesViewModel: BaseViewModel, ObservableObject {
             for member in expense.splitTo {
                 splitAmounts[member] = splitAmount
             }
+        case .fixedAmount:
+            if let splitData = expense.splitData {
+                for (member, fixedAmount) in splitData {
+                    splitAmounts[member] = fixedAmount
+                }
+            }
         case .percentage:
             if let splitData = expense.splitData {
                 let totalPercentage = splitData.values.reduce(0, +)

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
@@ -110,7 +110,7 @@ class GroupTransactionListViewModel: BaseViewModel, ObservableObject {
                       negativeBtnTitle: "Cancel",
                       negativeBtnAction: { self.showAlert = false })
     }
-    
+
     private func deleteTransaction(transactionId: String) {
         transactionRepository.deleteTransaction(transactionId: transactionId)
             .sink { [weak self] completion in

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailViewModel.swift
@@ -105,7 +105,7 @@ class GroupTransactionDetailViewModel: BaseViewModel, ObservableObject {
                       negativeBtnTitle: "Cancel",
                       negativeBtnAction: { self.showAlert = false })
     }
-    
+
     private func deleteTransaction() {
         viewState = .loading
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for splitting expenses by fixed amounts.

- **Improvements**
  - Simplified expense splitting logic to use a unified `splitData`.

- **Bug Fixes**
  - Fixed minor whitespace issues in group transaction view models.

- **User Interface**
  - Updated icons and text labels in the expense split options tab.
  - Introduced a new view for managing fixed amount splits.
  
- **View Models**
  - Enhanced the logic for calculating split amounts, including fixed amounts.
  - Streamlined expense-related variable names for clarity and consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->