### PR TITLE
Minor improvements and fixes

### DIFF
--- a/BaseStyle/BaseStyle.xcodeproj/project.pbxproj
+++ b/BaseStyle/BaseStyle.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		213F377A2C3EB23F00972316 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F37792C3EB23F00972316 /* BottomSheetView.swift */; };
+		213F377C2C400EC500972316 /* NumberFormatterHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F377B2C400EC500972316 /* NumberFormatterHelper.swift */; };
 		5DAEE93D2D2208132D031984 /* Pods_BaseStyleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4AFAF996FB5C233D40D81D5 /* Pods_BaseStyleTests.framework */; };
 		A40018A9B957803B8105BEA5 /* Pods_BaseStyle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 174198EE4AF2FC82DADEB060 /* Pods_BaseStyle.framework */; };
 		D82174BE2BBAD86D00DB42C3 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82174BD2BBAD86D00DB42C3 /* ProfileImageView.swift */; };
@@ -68,6 +70,8 @@
 
 /* Begin PBXFileReference section */
 		174198EE4AF2FC82DADEB060 /* Pods_BaseStyle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BaseStyle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		213F37792C3EB23F00972316 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
+		213F377B2C400EC500972316 /* NumberFormatterHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterHelper.swift; sourceTree = "<group>"; };
 		2CE85328C46B183FC3F074A3 /* Pods-BaseStyle.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyle.release.xcconfig"; path = "Target Support Files/Pods-BaseStyle/Pods-BaseStyle.release.xcconfig"; sourceTree = "<group>"; };
 		5BDB5B9B63CFD771230CD759 /* Pods-BaseStyleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyleTests.release.xcconfig"; path = "Target Support Files/Pods-BaseStyleTests/Pods-BaseStyleTests.release.xcconfig"; sourceTree = "<group>"; };
 		CC9EC1F1C0A5A0821118E6CA /* Pods-BaseStyleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyleTests.debug.xcconfig"; path = "Target Support Files/Pods-BaseStyleTests/Pods-BaseStyleTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -269,6 +273,7 @@
 				D8D42A9C2B870A5D009B345D /* ToastPrompt.swift */,
 				D8E244B42B972AD200C6C82A /* EmptyRouteView.swift */,
 				D89DBE302B8884E300E5F1BD /* SectionHeaderView.swift */,
+				213F37792C3EB23F00972316 /* BottomSheetView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -278,6 +283,7 @@
 			children = (
 				D887213E2B99992A009DC5BE /* LoaderViewModel.swift */,
 				D8D42AA22B8715B4009B345D /* TopViewController.swift */,
+				213F377B2C400EC500972316 /* NumberFormatterHelper.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -507,9 +513,11 @@
 				D89C933F2BC3C0F800FACD16 /* ForwardIcon.swift in Sources */,
 				D89DBE352B88A05F00E5F1BD /* UIApplication+Extension.swift in Sources */,
 				D89DBE3C2B88AA1500E5F1BD /* CustomTextField.swift in Sources */,
+				213F377C2C400EC500972316 /* NumberFormatterHelper.swift in Sources */,
 				D8D42A772B85CE2A009B345D /* ButtonStyleTapGestureModifier.swift in Sources */,
 				D8D42A832B85D07C009B345D /* View+Extension.swift in Sources */,
 				D89DBE3E2B8C67CE00E5F1BD /* String+Extension.swift in Sources */,
+				213F377A2C3EB23F00972316 /* BottomSheetView.swift in Sources */,
 				D8E244C32B986D4F00C6C82A /* UIImage+Extension.swift in Sources */,
 				D8D42A822B85D07C009B345D /* PrimaryButton.swift in Sources */,
 				D8D42A8A2B85D525009B345D /* AppColors.swift in Sources */,

--- a/BaseStyle/BaseStyle/CustomUI/SearchBar.swift
+++ b/BaseStyle/BaseStyle/CustomUI/SearchBar.swift
@@ -29,7 +29,7 @@ public struct SearchBar: UIViewRepresentable {
     public func makeUIView(context: UIViewRepresentableContext<SearchBar>) -> UISearchBar {
         let searchBar = UISearchBar(frame: .zero)
         searchBar.delegate = context.coordinator
-        searchBar.placeholder = placeholder
+        searchBar.placeholder = placeholder.localized
         searchBar.searchBarStyle = .minimal
         searchBar.showsCancelButton = showCancelButton
         searchBar.searchTextField.clearButtonMode = clearButtonMode

--- a/BaseStyle/BaseStyle/CustomUI/ToastView.swift
+++ b/BaseStyle/BaseStyle/CustomUI/ToastView.swift
@@ -22,11 +22,11 @@ struct ToastView: View {
                     .padding(.trailing, 4)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
+                    Text(title.localized)
                         .font(.buttonText())
                         .foregroundStyle(primaryText)
 
-                    Text(message)
+                    Text(message.localized)
                         .font(.body1(12))
                         .foregroundStyle(secondaryText)
                 }

--- a/BaseStyle/BaseStyle/Extension/View+Extension.swift
+++ b/BaseStyle/BaseStyle/Extension/View+Extension.swift
@@ -8,6 +8,46 @@
 import UIKit
 import SwiftUI
 
+public extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+public struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    public func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}
+
+public extension View {
+    func transparentFullScreenCover<Content: View>(isPresented: Binding<Bool>, content: @escaping () -> Content) -> some View {
+        fullScreenCover(isPresented: isPresented) {
+            ZStack {
+                content()
+            }
+            .background(TransparentBackground())
+        }
+    }
+}
+
+struct TransparentBackground: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        DispatchQueue.main.async {
+            view.superview?.superview?.backgroundColor = .clear
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
 public var isIpad: Bool {
     UIDevice.current.userInterfaceIdiom == .pad
 }

--- a/BaseStyle/BaseStyle/Helper/NumberFormatterHelper.swift
+++ b/BaseStyle/BaseStyle/Helper/NumberFormatterHelper.swift
@@ -1,0 +1,17 @@
+//
+//  NumberFormatterHelper.swift
+//  BaseStyle
+//
+//  Created by Nirali Sonani on 11/07/24.
+//
+
+import Foundation
+
+public var numberFormatter: NumberFormatter {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 2
+    formatter.maximumFractionDigits = 2
+    formatter.usesGroupingSeparator = false
+    return formatter
+}

--- a/BaseStyle/BaseStyle/Resource/AppColors.swift
+++ b/BaseStyle/BaseStyle/Resource/AppColors.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public let backgroundColor = Color.background
 public let awarenessColor = Color.awareness
 public let successColor = Color.success
+public let bottomSheetBgColor = Color.bottomSheetBg
 
 public let containerHighColor = Color.containerHigh
 public let containerLowColor = Color.containerLow

--- a/BaseStyle/BaseStyle/Resource/BaseAssets.xcassets/Colors/BottomSheetBgColor.colorset/Contents.json
+++ b/BaseStyle/BaseStyle/Resource/BaseAssets.xcassets/Colors/BottomSheetBgColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0x34",
+          "green" : "0x2D",
+          "red" : "0x28"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BaseStyle/BaseStyle/Views/AlertPrompt.swift
+++ b/BaseStyle/BaseStyle/Views/AlertPrompt.swift
@@ -55,7 +55,7 @@ public extension Backport where Content: View {
                     })
                 }
                 if alertStruct.positiveBtnTitle == nil && alertStruct.negativeBtnTitle == nil {
-                    Button("Ok", role: .cancel, action: {
+                    Button("Ok".localized, role: .cancel, action: {
                         isPresented.wrappedValue = false
                     })
                 }

--- a/BaseStyle/BaseStyle/Views/BottomSheetView.swift
+++ b/BaseStyle/BaseStyle/Views/BottomSheetView.swift
@@ -1,0 +1,98 @@
+//
+//  BottomSheetView.swift
+//  BaseStyle
+//
+//  Created by Amisha Italiya on 10/07/24.
+//
+
+import SwiftUI
+
+public struct BottomSheetView<Content>: View where Content: View {
+
+    public let content: () -> Content
+    public let onDismiss: () -> Void
+    @State var isAnimating: Bool = false
+
+    public init(content: @escaping () -> Content, onDismiss: @escaping () -> Void) {
+        self.content = content
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            BottomSheetContentView(isAnimating: $isAnimating, content: {
+                VStack(spacing: 0) {
+                    content()
+                }
+            }, onDismiss: {
+                performDisappearAnimation {
+                    onDismiss()
+                }
+            })
+        }
+    }
+
+    public func performDisappearAnimation(completion: (() -> Void)? = nil) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isAnimating = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
+            completion?()
+        })
+    }
+}
+
+public struct BottomSheetContentView<Content>: View where Content: View {
+
+    @Binding var isAnimating: Bool
+
+    private let content: () -> Content
+    private var onDismiss: (() -> Void)?
+
+    public init(isAnimating: Binding<Bool>, content: @escaping () -> Content, onDismiss: (() -> Void)? = nil) {
+        self._isAnimating = isAnimating
+        self.content = content
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 0) {
+                VSpacer()
+            }
+            .frame(maxWidth: .infinity)
+            .background(content: {
+                isAnimating ? (ZStack { bottomSheetBgColor }.ignoresSafeArea()) : nil
+            })
+            .onTapGesture {
+                performDismissAction()
+            }
+            .gesture(DragGesture().onEnded { _ in
+                performDismissAction()
+            })
+            .overlay(alignment: .bottom, content: {
+                VStack(spacing: 0, content: {
+                    content()
+                })
+                .background(backgroundColor)
+                .cornerRadius(16, corners: [.topLeft, .topRight])
+            })
+            .edgesIgnoringSafeArea(.bottom)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.28) {
+                withAnimation(.easeInOut(duration: 0.4)) {
+                    isAnimating = true
+                }
+            }
+        }
+    }
+
+    private func performDismissAction() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isAnimating = false
+        }
+        onDismiss?()
+    }
+}

--- a/Data/Data/Model/Expense.swift
+++ b/Data/Data/Model/Expense.swift
@@ -59,7 +59,7 @@ public enum SplitType: String, Codable, CaseIterable {
     case percentage
     case shares
 
-    public var tabIcon: String {
+    public var tabItem: String {
         switch self {
         case .equally:
             return "="

--- a/Splito/Localization/Localizable.xcstrings
+++ b/Splito/Localization/Localizable.xcstrings
@@ -19,6 +19,9 @@
     " to %@" : {
 
     },
+    "\"Simplify debts\" is ENABLED in this group. This feature shuffles \"who owes who\" to minimize repayments. For example:\n" : {
+
+    },
     "(%lld people)" : {
 
     },
@@ -77,6 +80,12 @@
         }
       }
     },
+    "%@ people" : {
+      "extractionState" : "manual"
+    },
+    "%@ people paid %@" : {
+      "extractionState" : "manual"
+    },
     "%@/person" : {
 
     },
@@ -89,11 +98,20 @@
     "0.00" : {
 
     },
+    "1.23" : {
+      "extractionState" : "manual"
+    },
     "About" : {
 
     },
     "Account" : {
 
+    },
+    "Acknowledgements" : {
+      "extractionState" : "manual"
+    },
+    "Acknowledgements cannot be accessed." : {
+      "extractionState" : "manual"
     },
     "Add & split expenses with groups or individuals." : {
       "extractionState" : "manual"
@@ -123,16 +141,49 @@
     "All time" : {
       "extractionState" : "manual"
     },
+    "Allow" : {
+      "extractionState" : "manual"
+    },
+    "Ana borrows $10 from Bob\nBob borrows $10 from Charlie\n" : {
+
+    },
     "and split" : {
 
     },
+    "Apologies, we were not able to complete the authentication process. Please try again later." : {
+      "extractionState" : "manual"
+    },
+    "Are you ABSOLUTELY sure you want to close your splito account? You will no longer be able to log into your account or access your account history from your splito app." : {
+      "extractionState" : "manual"
+    },
+    "Are you ABSOLUTELY sure you want to delete this group? This will remove this group for ALL users involved, not just yourself." : {
+      "extractionState" : "manual"
+    },
+    "Are you absolutely sure you want to leave this group?" : {
+      "extractionState" : "manual"
+    },
     "Are you sure you want to delete this expense? This will remove this expense for ALL people involved, not just you." : {
+      "extractionState" : "manual"
+    },
+    "Are you sure you want to delete this transaction?" : {
+      "extractionState" : "manual"
+    },
+    "Are you sure you want to remove this member from the group?" : {
+      "extractionState" : "manual"
+    },
+    "Are you sure you want to sign out?" : {
+      "extractionState" : "manual"
+    },
+    "Authentication failed" : {
       "extractionState" : "manual"
     },
     "Automatically combines debts to reduce the total number of repayments between group members." : {
 
     },
     "Balances" : {
+      "extractionState" : "manual"
+    },
+    "Camera access is required to take picture for your profile" : {
       "extractionState" : "manual"
     },
     "Cancel" : {
@@ -146,6 +197,15 @@
     },
     "Choose Payer" : {
 
+    },
+    "Contact Support" : {
+      "extractionState" : "manual"
+    },
+    "Contact us" : {
+      "extractionState" : "manual"
+    },
+    "Couldn't decode the response." : {
+      "extractionState" : "manual"
     },
     "Countries" : {
 
@@ -171,6 +231,12 @@
     "Delete group" : {
       "extractionState" : "manual"
     },
+    "Delete Transaction" : {
+      "extractionState" : "manual"
+    },
+    "Delete your account" : {
+      "extractionState" : "manual"
+    },
     "Details" : {
 
     },
@@ -189,10 +255,28 @@
     "Edit payment" : {
 
     },
+    "Email" : {
+      "extractionState" : "manual"
+    },
+    "Email sent successfully!" : {
+      "extractionState" : "manual"
+    },
     "Enter a description" : {
       "extractionState" : "manual"
     },
+    "Enter a valid phone number." : {
+      "extractionState" : "manual"
+    },
     "Enter code" : {
+      "extractionState" : "manual"
+    },
+    "Enter email" : {
+      "extractionState" : "manual"
+    },
+    "Enter first name" : {
+      "extractionState" : "manual"
+    },
+    "Enter last name" : {
       "extractionState" : "manual"
     },
     "Enter phone number" : {
@@ -204,13 +288,34 @@
     "Enter the percentage split that's fair for your situation." : {
       "extractionState" : "manual"
     },
+    "Entered code is expired." : {
+      "extractionState" : "manual"
+    },
+    "Entered code not exists." : {
+      "extractionState" : "manual"
+    },
+    "Entered number is too long, Please check the phone number." : {
+      "extractionState" : "manual"
+    },
     "equally" : {
+      "extractionState" : "manual"
+    },
+    "Error" : {
       "extractionState" : "manual"
     },
     "Expense date" : {
       "extractionState" : "manual"
     },
+    "Expense deleted successfully" : {
+      "extractionState" : "manual"
+    },
     "Expenses" : {
+      "extractionState" : "manual"
+    },
+    "Failed to perform database operation." : {
+      "extractionState" : "manual"
+    },
+    "First name" : {
       "extractionState" : "manual"
     },
     "Get Started" : {
@@ -227,6 +332,9 @@
     },
     "Group balances" : {
 
+    },
+    "Group member removed" : {
+      "extractionState" : "manual"
     },
     "Group members" : {
 
@@ -249,6 +357,15 @@
     "Groups make it easy to split apartment bills, share travel expenses, and more." : {
 
     },
+    "Important!" : {
+      "extractionState" : "manual"
+    },
+    "In a group with \"simplify debts\" enabled, Splito will tell Ana to repay Charlie $10. Bob does nothing. This is the most efficient way for the group to settle up. With simplify debts enabled, it's normal to owe someone who didn't directly loan you money." : {
+
+    },
+    "Invalid OTP" : {
+      "extractionState" : "manual"
+    },
     "Invite Code" : {
 
     },
@@ -267,7 +384,22 @@
     "keep track of balances between friends and loved ones." : {
       "extractionState" : "manual"
     },
+    "Key" : {
+      "extractionState" : "manual"
+    },
+    "Key 1" : {
+      "extractionState" : "manual"
+    },
+    "Key 2" : {
+      "extractionState" : "manual"
+    },
     "Last month" : {
+      "extractionState" : "manual"
+    },
+    "Last name" : {
+      "extractionState" : "manual"
+    },
+    "Leave" : {
       "extractionState" : "manual"
     },
     "Leave group" : {
@@ -275,6 +407,15 @@
     },
     "Leave Group" : {
 
+    },
+    "Leave Group?" : {
+      "extractionState" : "manual"
+    },
+    "Let's split the expense! Use invite code %@ to join the %@ group, don't have an app then please download it." : {
+      "extractionState" : "manual"
+    },
+    "Minimum 3 characters are required" : {
+      "extractionState" : "manual"
     },
     "More options" : {
 
@@ -297,6 +438,9 @@
     "No expenses here yet." : {
 
     },
+    "No internet connection!" : {
+      "extractionState" : "manual"
+    },
     "No members in your selected group." : {
 
     },
@@ -309,7 +453,16 @@
     "not involved" : {
 
     },
+    "Ok" : {
+      "extractionState" : "manual"
+    },
     "Oops" : {
+      "extractionState" : "manual"
+    },
+    "Oops!" : {
+      "extractionState" : "manual"
+    },
+    "over" : {
       "extractionState" : "manual"
     },
     "Overall, %@  " : {
@@ -336,8 +489,38 @@
     "Phone number" : {
 
     },
+    "Please enter a cost for your expense first!" : {
+      "extractionState" : "manual"
+    },
+    "Please enter valid email" : {
+      "extractionState" : "manual"
+    },
+    "Please enter valid phone number" : {
+      "extractionState" : "manual"
+    },
+    "Please fill all data to add expense." : {
+      "extractionState" : "manual"
+    },
+    "Please select group to get payer list." : {
+      "extractionState" : "manual"
+    },
+    "Please, enter a valid OTP code." : {
+      "extractionState" : "manual"
+    },
+    "Privacy" : {
+      "extractionState" : "manual"
+    },
+    "Privacy policy cannot be accessed." : {
+      "extractionState" : "manual"
+    },
     "Profile" : {
 
+    },
+    "Rate Splito" : {
+      "extractionState" : "manual"
+    },
+    "Reauthenticate" : {
+      "extractionState" : "manual"
     },
     "Record a payment" : {
 
@@ -347,6 +530,12 @@
     },
     "Remove from group" : {
 
+    },
+    "Remove from group?" : {
+      "extractionState" : "manual"
+    },
+    "requires recent authentication" : {
+      "extractionState" : "manual"
     },
     "Resend code" : {
 
@@ -360,10 +549,22 @@
     "Search expenses" : {
       "extractionState" : "manual"
     },
+    "Search groups" : {
+      "extractionState" : "manual"
+    },
+    "See you soon!" : {
+      "extractionState" : "manual"
+    },
     "Select group" : {
       "extractionState" : "manual"
     },
     "Select which people owe an equal share." : {
+      "extractionState" : "manual"
+    },
+    "Server error" : {
+      "extractionState" : "manual"
+    },
+    "Server error encountered." : {
       "extractionState" : "manual"
     },
     "Settings" : {
@@ -378,6 +579,9 @@
     "settled up" : {
 
     },
+    "Share app" : {
+      "extractionState" : "manual"
+    },
     "Share Code" : {
       "extractionState" : "manual"
     },
@@ -385,6 +589,9 @@
 
     },
     "share(s)" : {
+      "extractionState" : "manual"
+    },
+    "short" : {
       "extractionState" : "manual"
     },
     "Sign in with Apple" : {
@@ -404,6 +611,24 @@
     },
     "Simplify group debts" : {
 
+    },
+    "Someone" : {
+      "extractionState" : "manual"
+    },
+    "Something went wrong! Please try after some time." : {
+      "extractionState" : "manual"
+    },
+    "Something went wrong." : {
+      "extractionState" : "manual"
+    },
+    "Sorry, we can not perform your request as the data is already exists." : {
+      "extractionState" : "manual"
+    },
+    "Specify exactly how much each person owes." : {
+      "extractionState" : "manual"
+    },
+    "Split by exact amounts" : {
+      "extractionState" : "manual"
     },
     "Split by percentages" : {
       "extractionState" : "manual"
@@ -426,11 +651,26 @@
     "Stay In Touch" : {
 
     },
+    "Success" : {
+      "extractionState" : "manual"
+    },
     "Take Picture" : {
 
     },
     "Tap the plus button to add an expense with any group." : {
 
+    },
+    "The amounts do not add up to the total cost of %@. You are %@ by %@." : {
+      "extractionState" : "manual"
+    },
+    "The payment values do not add up to the total cost of ₹ %@. You are short by ₹ %@." : {
+      "extractionState" : "manual"
+    },
+    "The shares do not add up to 100%. You are %@ by %@%" : {
+      "extractionState" : "manual"
+    },
+    "The total of everyone's paid shares (₹%@) is different than the total cost (₹%@)" : {
+      "extractionState" : "manual"
     },
     "This code will be active for 2 days." : {
 
@@ -442,6 +682,9 @@
 
     },
     "Today" : {
+      "extractionState" : "manual"
+    },
+    "Too many attempts, please try after some time." : {
       "extractionState" : "manual"
     },
     "Total change in balance" : {
@@ -456,7 +699,13 @@
     "Total you paid for" : {
       "extractionState" : "manual"
     },
+    "Totals" : {
+      "extractionState" : "manual"
+    },
     "Tracking" : {
+      "extractionState" : "manual"
+    },
+    "Transaction deleted successfully" : {
       "extractionState" : "manual"
     },
     "Transactions" : {
@@ -465,10 +714,16 @@
     "unequally" : {
       "extractionState" : "manual"
     },
+    "Unknown" : {
+      "extractionState" : "manual"
+    },
     "Verification code" : {
       "extractionState" : "manual"
     },
     "Verify" : {
+      "extractionState" : "manual"
+    },
+    "Warning" : {
       "extractionState" : "manual"
     },
     "We'll verify your phone number with a verification code" : {
@@ -488,6 +743,9 @@
     },
     "Whoops!" : {
       "extractionState" : "manual"
+    },
+    "Why do I owe this person?" : {
+
     },
     "You" : {
       "extractionState" : "manual"
@@ -511,6 +769,9 @@
     "You are all settled up in this group." : {
 
     },
+    "You are an unauthorised user." : {
+      "extractionState" : "manual"
+    },
     "You are not part of any group." : {
 
     },
@@ -523,11 +784,20 @@
     "you borrowed" : {
 
     },
+    "You can't leave this group because you have outstanding debts with other group members. Please make sure all of your debts have been settle up, and try again." : {
+      "extractionState" : "manual"
+    },
+    "You can't remove %@ from this group because they have outstanding debts with other group members. Please make sure all of %@'s debts have been settle up, and try again." : {
+      "extractionState" : "manual"
+    },
     "You do not have any groups yet." : {
 
     },
     "you lent" : {
 
+    },
+    "You must assign a non-zero share to at least one person." : {
+      "extractionState" : "manual"
     },
     "You must enter an amount." : {
       "extractionState" : "manual"
@@ -552,6 +822,12 @@
     },
     "You're the only one here!" : {
 
+    },
+    "Your device cannot send email." : {
+      "extractionState" : "manual"
+    },
+    "Your requested data not found." : {
+      "extractionState" : "manual"
     },
     "Your total share" : {
       "extractionState" : "manual"

--- a/Splito/UI/Home/Account/AccountHomeView.swift
+++ b/Splito/UI/Home/Account/AccountHomeView.swift
@@ -156,7 +156,7 @@ private struct AccountItemCellView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            Text(optionText)
+            Text(optionText.localized)
                 .font(.subTitle2())
                 .foregroundStyle(primaryText)
 

--- a/Splito/UI/Home/Account/User Profile/UserProfileView.swift
+++ b/Splito/UI/Home/Account/User Profile/UserProfileView.swift
@@ -173,7 +173,7 @@ private struct UserDetailCell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(subtitleText)
+            Text(subtitleText.localized)
                 .font(.body2())
                 .lineSpacing(1)
                 .foregroundStyle(disableText)
@@ -191,7 +191,7 @@ private struct UserDetailCell: View {
                     Divider()
                         .frame(height: 1)
                         .background(awarenessColor)
-                    Text(validationType.errorText)
+                    Text(validationType.errorText.localized)
                         .font(.body1(12))
                         .foregroundStyle(awarenessColor)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerView.swift
+++ b/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerView.swift
@@ -35,8 +35,8 @@ struct ChooseMultiplePayerView: View {
                     }
                     .scrollIndicators(.hidden)
 
-                    BottomInfoCardView(title: "₹ \(String(format: "%.0f", viewModel.totalAmount)) of ₹ \(viewModel.expenseAmount)",
-                                       value: "₹ \(String(format: "%.0f", (viewModel.expenseAmount - viewModel.totalAmount))) left")
+                    BottomInfoCardView(title: "₹ \(String(format: "%.2f", viewModel.totalAmount)) of ₹ \(viewModel.expenseAmount)",
+                                       value: "₹ \(String(format: "%.2f", (viewModel.expenseAmount - viewModel.totalAmount))) left")
                 }
             }
         }
@@ -68,7 +68,9 @@ private struct EnterPaidAmountsView: View {
                         set: { viewModel.updateAmount(for: member.id, amount: $0) }
                     ),
                     member: member, suffixText: "₹",
+                    formatString: "%.2f",
                     expenseAmount: viewModel.totalAmount,
+                    inputFieldWidth: 80,
                     onChange: { amount in
                         viewModel.updateAmount(for: member.id, amount: amount)
                     }

--- a/Splito/UI/Home/Expense/Detail Selection/Payer/ChoosePayerView.swift
+++ b/Splito/UI/Home/Expense/Detail Selection/Payer/ChoosePayerView.swift
@@ -121,7 +121,7 @@ private struct ChooseMemberCellView: View {
             HStack(alignment: .center, spacing: 20) {
                 MemberProfileImageView(imageUrl: member.imageUrl)
 
-                Text((userName ?? "").isEmpty ? "Unknown" : userName!)
+                Text(((userName ?? "").isEmpty ? "Unknown" : userName?.localized) ?? "")
                     .font(.subTitle2())
                     .foregroundStyle(primaryText)
 

--- a/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsView.swift
+++ b/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsView.swift
@@ -47,7 +47,7 @@ struct ExpenseDetailsView: View {
         .frame(maxWidth: isIpad ? 600 : nil, alignment: .center)
         .fullScreenCover(isPresented: $viewModel.showEditExpenseSheet) {
             NavigationStack {
-                AddExpenseView(viewModel: AddExpenseViewModel(router: viewModel.router, expenseId: viewModel.expenseId))
+                AddExpenseView(viewModel: AddExpenseViewModel(router: viewModel.router, expenseId: viewModel.expenseId, onDismissSheet: viewModel.dismissEditExpenseSheet))
             }
         }
         .toolbar {
@@ -97,7 +97,7 @@ private struct ExpenseHeaderView: View {
                 .font(.H1Text(36))
                 .foregroundStyle(primaryText)
 
-            Text("Added by \(username) on \(viewModel.expense?.date.dateValue().longDate ?? "Today")")
+            Text("Added by \(username.localized) on \(viewModel.expense?.date.dateValue().longDate ?? "Today")")
                 .lineLimit(0)
                 .font(.body1(17))
                 .foregroundStyle(secondaryText)
@@ -153,13 +153,13 @@ private struct ExpenseInfoView: View {
                             if let paidBy = expense?.paidBy, paidBy.contains(where: { $0.key == userData.id }), paidBy.count > 1 {
                                 MemberProfileImageView(imageUrl: userData.imageUrl, height: subImageHeight)
                                 if let splitTo = expense?.splitTo, splitTo.contains(userData.id) {
-                                    Text("\(memberName.localized) paid \(paidAmount.formattedCurrency) and \(owes) \(splitAmount)")
+                                    Text("\(memberName.localized) paid \(paidAmount.formattedCurrency) and \(owes.localized) \(splitAmount)")
                                 } else {
                                     Text("\(memberName.localized) paid \(paidAmount.formattedCurrency)")
                                 }
                             } else if let splitTo = expense?.splitTo, splitTo.contains(userData.id) {
                                 MemberProfileImageView(imageUrl: userData.imageUrl, height: subImageHeight)
-                                Text("\(memberName.localized) \(owes) \(splitAmount)")
+                                Text("\(memberName.localized) \(owes.localized) \(splitAmount)")
                             }
                         }
                     }

--- a/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsViewModel.swift
+++ b/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsViewModel.swift
@@ -80,6 +80,11 @@ class ExpenseDetailsViewModel: BaseViewModel, ObservableObject {
     }
 
     // MARK: - User Actions
+    func dismissEditExpenseSheet() {
+        showEditExpenseSheet = false
+        fetchExpense()
+    }
+
     func getMemberDataBy(id: String) -> AppUser? {
         return expenseUsersData.first(where: { $0.id == id })
     }

--- a/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
+++ b/Splito/UI/Home/Expense/Expense Split Option/ExpenseSplitOptionsView.swift
@@ -69,6 +69,9 @@ struct ExpenseSplitOptionsView: View {
                 .foregroundStyle(primaryColor)
             }
         }
+        .onTapGesture {
+            UIApplication.shared.endEditing()
+        }
     }
 }
 
@@ -102,8 +105,8 @@ private struct SplitOptionsBottomView: View {
             ExpenseSplitAmountView(memberCount: viewModel.selectedMembers.count, splitAmount: viewModel.splitAmount,
                                    isAllSelected: viewModel.isAllSelected, onAllBtnTap: viewModel.handleAllBtnAction)
         case .fixedAmount:
-            BottomInfoCardView(title: "₹ \(String(format: "%.0f", viewModel.totalFixedAmount)) of ₹ \(viewModel.totalAmount)",
-                               value: "₹ \(String(format: "%.0f", (viewModel.totalAmount - viewModel.totalFixedAmount))) left")
+            BottomInfoCardView(title: "₹ \(String(format: "%.2f", viewModel.totalFixedAmount)) of ₹ \(viewModel.expenseAmount)",
+                               value: "₹ \(String(format: "%.2f", (viewModel.expenseAmount - viewModel.totalFixedAmount))) left")
         case .percentage:
             BottomInfoCardView(title: "\(String(format: "%.0f", viewModel.totalPercentage))% of 100%",
                                value: "\(String(format: "%.0f", 100 - viewModel.totalPercentage))% left")
@@ -212,5 +215,5 @@ struct BottomInfoCardView: View {
 }
 
 #Preview {
-    ExpenseSplitOptionsView(viewModel: ExpenseSplitOptionsViewModel(amount: 0, members: [], selectedMembers: [], handleSplitTypeSelection: {_, _, _ in }))
+    ExpenseSplitOptionsView(viewModel: ExpenseSplitOptionsViewModel(amount: 0, splitData: [:], members: [], selectedMembers: [], handleSplitTypeSelection: {_, _, _ in }))
 }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/GroupSettleUpView.swift
@@ -136,7 +136,7 @@ private struct GroupMemberCellView: View {
                     .font(.body1())
                     .foregroundStyle(primaryText)
 
-                Text(subInfo)
+                Text(subInfo.localized)
                     .lineLimit(1)
                     .font(.subTitle3())
                     .foregroundStyle(secondaryText)

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentView.swift
@@ -34,7 +34,7 @@ struct GroupPaymentView: View {
                         }
                         .padding(.top, 20)
 
-                        Text("\(viewModel.payerName) paid \(viewModel.payableName)")
+                        Text("\(viewModel.payerName.localized) paid \(viewModel.payableName.localized)")
                             .font(.body1())
                             .foregroundStyle(primaryText)
 
@@ -45,6 +45,7 @@ struct GroupPaymentView: View {
 
                             DatePicker("", selection: $viewModel.paymentDate, in: ...viewModel.maximumDate, displayedComponents: .date)
                                 .labelsHidden()
+                                .onTapGesture(count: 99) {}
                         }
                         .padding(.top, 16)
 
@@ -72,6 +73,9 @@ struct GroupPaymentView: View {
             }
         }
         .scrollIndicators(.hidden)
+        .onTapGesture {
+            UIApplication.shared.endEditing()
+        }
     }
 }
 
@@ -87,8 +91,8 @@ private struct GroupPaymentAmountView: View {
                 .frame(width: 30, height: 30)
                 .padding(.top, 5)
 
-            TextField("0.00", value: $amount, formatter: NumberFormatter())
-                .keyboardType(.numberPad)
+            TextField("0.00", value: $amount, formatter: numberFormatter)
+                .keyboardType(.decimalPad)
                 .frame(width: 140)
                 .font(.Header1(30))
                 .focused($isAmountFocused)

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListView.swift
@@ -127,7 +127,7 @@ private struct TransactionItemView: View {
                 .frame(width: 1)
                 .background(outlineColor)
 
-            Text("\(payerName) paid \(receiverName) \(transactionWithUser.transaction.amount.formattedCurrency).")
+            Text("\(payerName.localized) paid \(receiverName.localized) \(transactionWithUser.transaction.amount.formattedCurrency).")
                 .font(.body1(17))
                 .foregroundStyle(primaryText)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListViewModel.swift
@@ -103,7 +103,7 @@ class GroupTransactionListViewModel: BaseViewModel, ObservableObject {
         guard let transactionId else { return }
 
         showAlert = true
-        alert = .init(title: "Delete transaction",
+        alert = .init(title: "Delete Transaction",
                       message: "Are you sure you want to delete this transaction?",
                       positiveBtnTitle: "Ok",
                       positiveBtnAction: { self.deleteTransaction(transactionId: transactionId) },

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailView.swift
@@ -108,7 +108,7 @@ private struct TransactionInfoView: View {
                 .frame(width: 50, height: 60)
                 .padding(10)
 
-            Text("\(payerName) paid \(receiverName)")
+            Text("\(payerName.localized) paid \(receiverName.localized)")
                 .font(.body1(22))
                 .foregroundStyle(primaryText)
 
@@ -116,7 +116,7 @@ private struct TransactionInfoView: View {
                 .font(.H1Text(36))
                 .foregroundStyle(primaryText)
 
-            Text("Added by \(addedUserName) on \(viewModel.transaction?.date.dateValue().longDate ?? "Today")")
+            Text("Added by \(addedUserName.localized) on \(viewModel.transaction?.date.dateValue().longDate ?? "Today")")
                 .lineLimit(0)
                 .font(.body1())
                 .foregroundStyle(secondaryText)

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/Transaction Detail/GroupTransactionDetailViewModel.swift
@@ -98,7 +98,7 @@ class GroupTransactionDetailViewModel: BaseViewModel, ObservableObject {
 
     func handleDeleteBtnAction() {
         showAlert = true
-        alert = .init(title: "Delete transaction",
+        alert = .init(title: "Delete Transaction",
                       message: "Are you sure you want to delete this transaction?",
                       positiveBtnTitle: "Ok",
                       positiveBtnAction: { self.deleteTransaction() },

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -47,6 +47,11 @@ struct GroupHomeView: View {
                 }
             }
         }
+        .transparentFullScreenCover(isPresented: $viewModel.showSimplifyInfoSheet, content: {
+            BottomSheetView(content: {
+                SimplifyInfoSheetView()
+            }, onDismiss: viewModel.dismissSimplifyInfoSheet)
+        })
         .fullScreenCover(isPresented: $viewModel.showTransactionsSheet) {
             GroupTransactionsRouteView(appRoute: .init(root: .TransactionListView(groupId: viewModel.group?.id ?? ""))) {
                 viewModel.showTransactionsSheet = false
@@ -84,7 +89,9 @@ struct GroupHomeView: View {
         .onAppear(perform: viewModel.fetchGroupAndExpenses)
         .onDisappear {
             isFocused = false
-            viewModel.onSearchBarCancelBtnTap()
+            if viewModel.showSearchBar {
+                viewModel.onSearchBarCancelBtnTap()
+            }
         }
     }
 }

--- a/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeViewModel.swift
@@ -28,6 +28,7 @@ class GroupHomeViewModel: BaseViewModel, ObservableObject {
     @Published var showBalancesSheet = false
     @Published var showGroupTotalSheet = false
     @Published private(set) var showSearchBar = false
+    @Published var showSimplifyInfoSheet: Bool = false
 
     @Published private(set) var group: Groups?
 
@@ -302,6 +303,14 @@ extension GroupHomeViewModel {
 
     func handleTransactionsBtnTap() {
         showTransactionsSheet = true
+    }
+
+    func handleSimplifyInfoSheet() {
+        showSimplifyInfoSheet = true
+    }
+
+    func dismissSimplifyInfoSheet() {
+        showSimplifyInfoSheet = false
     }
 
     func handleSearchOptionTap() {

--- a/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingView.swift
+++ b/Splito/UI/Home/Groups/Group/More Options/Group Setting/GroupSettingView.swift
@@ -231,7 +231,7 @@ private struct GroupMemberCellView: View {
 
             VStack(alignment: .leading, spacing: 5) {
                 HStack(alignment: .center, spacing: 2) {
-                    Text(userName)
+                    Text(userName.localized)
                         .lineLimit(1)
                         .font(.body1())
                         .foregroundStyle(primaryText)
@@ -243,7 +243,7 @@ private struct GroupMemberCellView: View {
                     }
                 }
 
-                Text(subInfo)
+                Text(subInfo.localized)
                     .lineLimit(1)
                     .font(.subTitle3())
                     .foregroundStyle(secondaryText)

--- a/Splito/UI/Home/Groups/GroupListView.swift
+++ b/Splito/UI/Home/Groups/GroupListView.swift
@@ -219,7 +219,7 @@ private struct GroupExpenseMemberOweView: View {
     var body: some View {
         if amount > 0 {
             Group {
-                Text("\(name) owes you ")
+                Text("\(name.localized) owes you ")
                     .foregroundColor(secondaryText)
                 + Text("\(amount.formattedCurrency)")
                     .foregroundColor(amountLentColor)


### PR DESCRIPTION
- [x] Dismiss keyboard on tap of outside in split expense options screen & payment screen 
- [x] Show expense details screen after edit expense
- [x] Fix: pass double value for settle up but in the record a payment view its not showing the floating points and not showing the floating points in add expense screen amount
- [x] Fix: hide search bar on disappear only if the search bar is visible 
- [x] Fix: payer count getting wrong in add expense sheet 
- [x] When there is multiple payers and member tries to change amount greater or less than paid amount then show alert & also there is 1.23 split type and change amount then show alert 
- [x] On add expense screen default focus should be on expense name text field
- [x] Fix: not able to open date picker on tap of date in add expense sheet
- [x] Add question mark beside expense amount in simplify group and on tap open info 
- [x] Fix not able to add expense when choose payer not open and save expense 
- [x] Localized all strings in whole project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `SimplifyInfoSheet` pop-up in the Group Home view.
  
- **Improvements**
  - Enhanced localization support for user names and supplementary information in Group Settings.
  - Improved localization for member owed amount details in Group List view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->