### PR TITLE
Add extra supports

### DIFF
--- a/BaseStyle/BaseStyle.xcodeproj/project.pbxproj
+++ b/BaseStyle/BaseStyle.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		213F377A2C3EB23F00972316 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F37792C3EB23F00972316 /* BottomSheetView.swift */; };
 		213F377C2C400EC500972316 /* NumberFormatterHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F377B2C400EC500972316 /* NumberFormatterHelper.swift */; };
+		213F377E2C416C9C00972316 /* ScrollToTopButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F377D2C416C9C00972316 /* ScrollToTopButton.swift */; };
 		5DAEE93D2D2208132D031984 /* Pods_BaseStyleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4AFAF996FB5C233D40D81D5 /* Pods_BaseStyleTests.framework */; };
 		A40018A9B957803B8105BEA5 /* Pods_BaseStyle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 174198EE4AF2FC82DADEB060 /* Pods_BaseStyle.framework */; };
 		D82174BE2BBAD86D00DB42C3 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82174BD2BBAD86D00DB42C3 /* ProfileImageView.swift */; };
@@ -72,6 +73,7 @@
 		174198EE4AF2FC82DADEB060 /* Pods_BaseStyle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BaseStyle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		213F37792C3EB23F00972316 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		213F377B2C400EC500972316 /* NumberFormatterHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterHelper.swift; sourceTree = "<group>"; };
+		213F377D2C416C9C00972316 /* ScrollToTopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollToTopButton.swift; sourceTree = "<group>"; };
 		2CE85328C46B183FC3F074A3 /* Pods-BaseStyle.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyle.release.xcconfig"; path = "Target Support Files/Pods-BaseStyle/Pods-BaseStyle.release.xcconfig"; sourceTree = "<group>"; };
 		5BDB5B9B63CFD771230CD759 /* Pods-BaseStyleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyleTests.release.xcconfig"; path = "Target Support Files/Pods-BaseStyleTests/Pods-BaseStyleTests.release.xcconfig"; sourceTree = "<group>"; };
 		CC9EC1F1C0A5A0821118E6CA /* Pods-BaseStyleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaseStyleTests.debug.xcconfig"; path = "Target Support Files/Pods-BaseStyleTests/Pods-BaseStyleTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				D8D42A7E2B85D07C009B345D /* PrimaryButton.swift */,
 				D8D42A7D2B85D07C009B345D /* SecondaryButton.swift */,
 				D8302D9B2B9EE1D2005ACA13 /* PrimaryFloatingButton.swift */,
+				213F377D2C416C9C00972316 /* ScrollToTopButton.swift */,
 			);
 			path = Buttons;
 			sourceTree = "<group>";
@@ -510,6 +513,7 @@
 				D8D42AB02B872E44009B345D /* LoaderView.swift in Sources */,
 				D8D42A9D2B870A5D009B345D /* ToastPrompt.swift in Sources */,
 				D82174BE2BBAD86D00DB42C3 /* ProfileImageView.swift in Sources */,
+				213F377E2C416C9C00972316 /* ScrollToTopButton.swift in Sources */,
 				D89C933F2BC3C0F800FACD16 /* ForwardIcon.swift in Sources */,
 				D89DBE352B88A05F00E5F1BD /* UIApplication+Extension.swift in Sources */,
 				D89DBE3C2B88AA1500E5F1BD /* CustomTextField.swift in Sources */,

--- a/BaseStyle/BaseStyle/CustomUI/Buttons/ScrollToTopButton.swift
+++ b/BaseStyle/BaseStyle/CustomUI/Buttons/ScrollToTopButton.swift
@@ -1,0 +1,38 @@
+//
+//  ScrollToTopButton.swift
+//  BaseStyle
+//
+//  Created by Nirali Sonani on 12/07/24.
+//
+
+import SwiftUI
+
+public struct ScrollToTopButton: View {
+    private let onClick: (() -> Void)?
+
+    public init(onClick: (() -> Void)? = nil) {
+        self.onClick = onClick
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            VSpacer()
+
+            Button(action: {
+                onClick?()
+            }, label: {
+                Image(systemName: "chevron.up")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(surfaceLightColor)
+                    .padding(10)
+                    .background(primaryColor)
+                    .clipShape(Circle())
+                    .padding([.trailing, .bottom], 16)
+            })
+            .buttonStyle(.scale)
+        }
+        .frame(maxWidth: .infinity, alignment: .bottomTrailing)
+    }
+}

--- a/BaseStyle/BaseStyle/CustomUI/OtpTextInputView.swift
+++ b/BaseStyle/BaseStyle/CustomUI/OtpTextInputView.swift
@@ -44,6 +44,7 @@ public struct OtpTextInputView: View {
                         UIApplication.shared.endEditing()
                     }
                 }
+                .autocapitalization(.none)
 
             Divider()
                 .background(outlineColor)

--- a/Data/Data/Router/AppRoute.swift
+++ b/Data/Data/Router/AppRoute.swift
@@ -38,7 +38,7 @@ public enum AppRoute: Hashable {
     case TransactionDetailView(transactionId: String, groupId: String)
 
     // MARK: - Expense Button
-    case AddExpenseView(expenseId: String?, groupId: String?)
+    case AddExpenseView(expenseId: String?)
     case ExpenseDetailView(expenseId: String)
     case ChoosePayerView(groupId: String, amount: Double, selectedPayer: [String: Double], onPayerSelection: (([String: Double]) -> Void))
     case ChooseMultiplePayerView(groupId: String, selectedPayers: [String: Double], amount: Double, onPayerSelection: (([String: Double]) -> Void))

--- a/Splito/Localization/Localizable.xcstrings
+++ b/Splito/Localization/Localizable.xcstrings
@@ -393,9 +393,6 @@
     "Key 2" : {
       "extractionState" : "manual"
     },
-    "Last month" : {
-      "extractionState" : "manual"
-    },
     "Last name" : {
       "extractionState" : "manual"
     },
@@ -460,6 +457,9 @@
       "extractionState" : "manual"
     },
     "Oops!" : {
+      "extractionState" : "manual"
+    },
+    "Oops! No groups here... yet!" : {
       "extractionState" : "manual"
     },
     "over" : {
@@ -680,6 +680,9 @@
     },
     "This payment was added using the \"record a payment\" feature. No money has been moved." : {
 
+    },
+    "This year" : {
+      "extractionState" : "manual"
     },
     "Today" : {
       "extractionState" : "manual"

--- a/Splito/UI/Home/Expense/AddExpenseView.swift
+++ b/Splito/UI/Home/Expense/AddExpenseView.swift
@@ -112,7 +112,7 @@ private struct ExpenseDetailRow: View {
     var field: AddExpenseViewModel.AddExpenseField?
     var keyboardType: UIKeyboardType = .default
 
-    let maximumDate = Calendar.current.date(byAdding: .year, value: 0, to: Date())!
+    let maximumDate = Calendar.current.date(byAdding: .year, value: 0, to: Date()) ?? Date()
 
     var body: some View {
         HStack(spacing: 16) {
@@ -237,5 +237,5 @@ private struct PaidByBtnView: View {
 }
 
 #Preview {
-    AddExpenseView(viewModel: AddExpenseViewModel(router: .init(root: .AddExpenseView(expenseId: "", groupId: ""))))
+    AddExpenseView(viewModel: AddExpenseViewModel(router: .init(root: .AddExpenseView(expenseId: ""))))
 }

--- a/Splito/UI/Home/Expense/AddExpenseViewModel.swift
+++ b/Splito/UI/Home/Expense/AddExpenseViewModel.swift
@@ -47,7 +47,7 @@ class AddExpenseViewModel: BaseViewModel, ObservableObject {
     private let onDismissSheet: (() -> Void)?
     private let router: Router<AppRoute>
 
-    init(router: Router<AppRoute>, expenseId: String? = nil, groupId: String? = nil, onDismissSheet: (() -> Void)? = nil) {
+    init(router: Router<AppRoute>, expenseId: String? = nil, onDismissSheet: (() -> Void)? = nil) {
         self.router = router
         self.expenseId = expenseId
         self.onDismissSheet = onDismissSheet
@@ -56,29 +56,12 @@ class AddExpenseViewModel: BaseViewModel, ObservableObject {
 
         if let expenseId {
             fetchExpenseDetails(expenseId: expenseId)
-        } else if let groupId {
-            fetchGroup(groupId: groupId)
+        } else {
             fetchDefaultUser()
         }
     }
 
     // MARK: - Data Loading
-    private func fetchGroup(groupId: String) {
-        viewState = .loading
-        groupRepository.fetchGroupBy(id: groupId)
-            .sink { [weak self] completion in
-                if case .failure(let error) = completion {
-                    self?.handleServerError(error)
-                }
-            } receiveValue: { [weak self] group in
-                guard let self, let group else { return }
-                self.selectedGroup = group
-                self.groupMembers = group.members
-                self.selectedMembers = group.members
-                self.viewState = .initial
-            }.store(in: &cancelable)
-    }
-
     private func fetchDefaultUser() {
         guard let id = preference.user?.id else { return }
         viewState = .loading
@@ -176,7 +159,6 @@ extension AddExpenseViewModel {
     }
 
     func handleGroupSelection(group: Groups) {
-        selectedPayers = [:]
         selectedGroup = group
         groupMembers = group.members
         selectedMembers = group.members

--- a/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerView.swift
+++ b/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerView.swift
@@ -52,6 +52,9 @@ struct ChooseMultiplePayerView: View {
                 }
             }
         }
+        .onTapGesture {
+            UIApplication.shared.endEditing()
+        }
     }
 }
 

--- a/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerViewModel.swift
+++ b/Splito/UI/Home/Expense/Detail Selection/Payer/ChooseMultiplePayerViewModel.swift
@@ -68,7 +68,11 @@ class ChooseMultiplePayerViewModel: BaseViewModel, ObservableObject {
 
     func handleDoneBtnTap() {
         if totalAmount != expenseAmount {
-            showAlertFor(title: "Oops!", message: "The payment values do not add up to the total cost of \(expenseAmount.formattedCurrency). You are short by \((expenseAmount - totalAmount).formattedCurrency).")
+            let amountDescription = totalAmount < expenseAmount ? "short" : "over"
+            let differenceAmount = totalAmount < expenseAmount ? (expenseAmount - totalAmount) : (totalAmount - expenseAmount)
+
+            showAlertFor(title: "Oops!",
+                         message: "The payment values do not add up to the total cost of \(expenseAmount.formattedCurrency). You are \(amountDescription) by \(differenceAmount.formattedCurrency).")
             return
         }
 

--- a/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsViewModel.swift
+++ b/Splito/UI/Home/Expense/Expense Detail/ExpenseDetailsViewModel.swift
@@ -95,7 +95,7 @@ class ExpenseDetailsViewModel: BaseViewModel, ObservableObject {
 
     func handleDeleteBtnAction() {
         showAlert = true
-        alert = .init(title: "Delete expense",
+        alert = .init(title: "Delete Expense",
                       message: "Are you sure you want to delete this expense? This will remove this expense for ALL people involved, not just you.",
                       positiveBtnTitle: "Ok",
                       positiveBtnAction: { self.deleteExpense() },

--- a/Splito/UI/Home/Expense/ExpenseRouteView.swift
+++ b/Splito/UI/Home/Expense/ExpenseRouteView.swift
@@ -11,20 +11,13 @@ import BaseStyle
 
 struct ExpenseRouteView: View {
 
-    @StateObject var appRoute: Router<AppRoute>
-
-    let groupId: String?
-
-    init(groupId: String? = nil) {
-        self.groupId = groupId
-        _appRoute = StateObject(wrappedValue: Router(root: AppRoute.AddExpenseView(expenseId: nil, groupId: groupId)))
-    }
+    @StateObject var appRoute = Router(root: AppRoute.AddExpenseView(expenseId: nil))
 
     var body: some View {
         RouterView(router: appRoute) { route in
             switch route {
-            case .AddExpenseView(let expenseId, let groupId):
-                AddExpenseView(viewModel: AddExpenseViewModel(router: appRoute, expenseId: expenseId, groupId: groupId))
+            case .AddExpenseView(let expenseId):
+                AddExpenseView(viewModel: AddExpenseViewModel(router: appRoute, expenseId: expenseId))
             default:
                 EmptyRouteView(routeName: self)
             }

--- a/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Settle up/Payment/GroupPaymentViewModel.swift
@@ -17,7 +17,7 @@ class GroupPaymentViewModel: BaseViewModel, ObservableObject {
 
     @Published var amount: Double = 0
     @Published var paymentDate = Date()
-    @Published private(set) var maximumDate = Calendar.current.date(byAdding: .year, value: 0, to: Date())!
+    @Published private(set) var maximumDate = Calendar.current.date(byAdding: .year, value: 0, to: Date()) ?? Date()
 
     @Published private(set) var payer: AppUser?
     @Published private(set) var receiver: AppUser?

--- a/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Totals/GroupTotalsViewModel.swift
@@ -101,11 +101,12 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
 
     private func filterItemsForSelectedTab<T>(items: [T], dateExtractor: (T) -> Date, for tab: GroupTotalsTabType) -> [T] {
         let calendar = Calendar.current
+        let currentDate = Date()
 
         switch tab {
         case .thisMonth:
-            let currentMonth = calendar.component(.month, from: Date())
-            let currentYear = calendar.component(.year, from: Date())
+            let currentMonth = calendar.component(.month, from: currentDate)
+            let currentYear = calendar.component(.year, from: currentDate)
 
             return items.filter {
                 let itemDate = dateExtractor($0)
@@ -113,20 +114,13 @@ class GroupTotalsViewModel: BaseViewModel, ObservableObject {
                 let itemYear = calendar.component(.year, from: itemDate)
                 return itemMonth == currentMonth && itemYear == currentYear
             }
-        case .lastMonth:
-            let currentDate = Date()
-            guard let lastMonthDate = calendar.date(byAdding: .month, value: -1, to: currentDate) else {
-                return []
-            }
-
-            let lastMonth = calendar.component(.month, from: lastMonthDate)
-            let lastMonthYear = calendar.component(.year, from: lastMonthDate)
+        case .thisYear:
+            let currentYear = calendar.component(.year, from: currentDate)
 
             return items.filter {
                 let itemDate = dateExtractor($0)
-                let itemMonth = calendar.component(.month, from: itemDate)
                 let itemYear = calendar.component(.year, from: itemDate)
-                return itemMonth == lastMonth && itemYear == lastMonthYear
+                return itemYear == currentYear
             }
         case .allTime:
             return items
@@ -189,14 +183,14 @@ extension GroupTotalsViewModel {
 // MARK: - Tab Types
 enum GroupTotalsTabType: Int, CaseIterable {
 
-    case thisMonth, lastMonth, allTime
+    case thisMonth, thisYear, allTime
 
     var tabItem: String {
         switch self {
         case .thisMonth:
             return "This month"
-        case .lastMonth:
-            return "Last month"
+        case .thisYear:
+            return "This year"
         case .allTime:
             return "All time"
         }

--- a/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListView.swift
+++ b/Splito/UI/Home/Groups/Group/Group Options/Transactions/GroupTransactionListView.swift
@@ -61,7 +61,7 @@ private struct TransactionListWithDetailView: View {
                     } else {
                         ForEach(viewModel.filteredTransactions.keys.sorted(by: viewModel.sortMonthYearStrings), id: \.self) { month in
                             Section(header: sectionHeader(month: month)) {
-                                ForEach(viewModel.filteredTransactions[month]!, id: \.transaction.id) { transaction in
+                                ForEach(viewModel.filteredTransactions[month] ?? [], id: \.transaction.id) { transaction in
                                     TransactionItemView(transactionWithUser: transaction)
                                         .onTouchGesture {
                                             viewModel.handleTransactionItemTap(transaction.transaction.id)

--- a/Splito/UI/Home/Groups/Group/GroupHomeView.swift
+++ b/Splito/UI/Home/Groups/Group/GroupHomeView.swift
@@ -25,9 +25,9 @@ struct GroupHomeView: View {
             } else if case .hasExpense = viewModel.groupState {
                 VSpacer(10)
 
-                GroupExpenseListView(viewModel: viewModel, isFocused: $isFocused, onSearchBarAppear: {
+                GroupExpenseListView(viewModel: viewModel, isFocused: $isFocused) {
                     isFocused = true
-                })
+                }
                 .focused($isFocused)
             }
         }
@@ -202,5 +202,5 @@ private struct NoExpenseView: View {
 }
 
 #Preview {
-    GroupHomeView(viewModel: GroupHomeViewModel(router: .init(root: .GroupHomeView(groupId: "")), groupId: "", onGroupSelected: ({_ in})))
+    GroupHomeView(viewModel: GroupHomeViewModel(router: .init(root: .GroupHomeView(groupId: "")), groupId: ""))
 }

--- a/Splito/UI/Home/Groups/GroupRouteView.swift
+++ b/Splito/UI/Home/Groups/GroupRouteView.swift
@@ -13,15 +13,13 @@ struct GroupRouteView: View {
 
     @StateObject var appRoute = Router(root: AppRoute.GroupListView)
 
-    let onGroupSelected: (String?) -> Void
-
     var body: some View {
         RouterView(router: appRoute) { route in
             switch route {
             case .GroupListView:
                 GroupListView(viewModel: GroupListViewModel(router: appRoute))
             case .GroupHomeView(let id):
-                GroupHomeView(viewModel: GroupHomeViewModel(router: appRoute, groupId: id, onGroupSelected: onGroupSelected))
+                GroupHomeView(viewModel: GroupHomeViewModel(router: appRoute, groupId: id))
             case .CreateGroupView(let group):
                 CreateGroupView(viewModel: CreateGroupViewModel(router: appRoute, group: group))
             case .InviteMemberView(let id):
@@ -32,8 +30,8 @@ struct GroupRouteView: View {
                 GroupSettingView(viewModel: GroupSettingViewModel(router: appRoute, groupId: id))
             case .ExpenseDetailView(let expenseId):
                 ExpenseDetailsView(viewModel: ExpenseDetailsViewModel(router: appRoute, expenseId: expenseId))
-            case .AddExpenseView(let expenseId, let groupId):
-                AddExpenseView(viewModel: AddExpenseViewModel(router: appRoute, expenseId: expenseId, groupId: groupId))
+            case .AddExpenseView(let expenseId):
+                AddExpenseView(viewModel: AddExpenseViewModel(router: appRoute, expenseId: expenseId))
             case .TransactionListView(let groupId):
                 GroupTransactionListView(viewModel: GroupTransactionListViewModel(router: appRoute, groupId: groupId))
             case .TransactionDetailView(let transactionId, let groupId):

--- a/Splito/UI/Home/HomeRouteView.swift
+++ b/Splito/UI/Home/HomeRouteView.swift
@@ -15,7 +15,7 @@ struct HomeRouteView: View {
     var body: some View {
         ZStack {
             TabView(selection: $viewModel.selectedTab) {
-                GroupRouteView(onGroupSelected: viewModel.setSelectedGroupId(_:))
+                GroupRouteView()
                     .onAppear {
                         viewModel.setLastSelectedTab(0)
                     }
@@ -46,7 +46,7 @@ struct HomeRouteView: View {
                 }
             }
             .fullScreenCover(isPresented: $viewModel.openExpenseSheet) {
-                ExpenseRouteView(groupId: viewModel.selectedGroupId)
+                ExpenseRouteView()
             }
             .sheet(isPresented: $viewModel.openProfileView) {
                 UserProfileView(viewModel: UserProfileViewModel(router: nil, isOpenFromOnboard: true, onDismiss: viewModel.dismissProfileView))

--- a/Splito/UI/Home/HomeRouteViewModel.swift
+++ b/Splito/UI/Home/HomeRouteViewModel.swift
@@ -18,7 +18,6 @@ class HomeRouteViewModel: ObservableObject {
 
     @Published var selectedTab = 0
     @Published private(set) var lastSelectedTab = 0
-    @Published private(set) var selectedGroupId: String?
 
     func openUserProfileIfNeeded() {
         if preference.isVerifiedUser {
@@ -30,12 +29,6 @@ class HomeRouteViewModel: ObservableObject {
 
     func setLastSelectedTab(_ index: Int) {
         lastSelectedTab = index
-    }
-
-    func setSelectedGroupId(_ groupId: String?) {
-        DispatchQueue.main.async {
-            self.selectedGroupId = groupId
-        }
     }
 
     func openAddExpenseSheet() {

--- a/Splito/UI/Login/LoginViewModel.swift
+++ b/Splito/UI/Login/LoginViewModel.swift
@@ -21,7 +21,7 @@ public class LoginViewModel: BaseViewModel, ObservableObject {
     @Published private(set) var showAppleLoading = false
 
     private var currentNonce: String = ""
-    private var appleSignInDelegates: SignInWithAppleDelegates! = nil
+    private var appleSignInDelegates: SignInWithAppleDelegates?
     private let router: Router<AppRoute>
 
     init(router: Router<AppRoute>) {


### PR DESCRIPTION
- [x] Fix split fixed amounts according to selected members in split option 1.23
- [x] Add scroll to top button in group list and group home screen
- [x] Fixed group list sorting order is changed after run the app 
- [x] In the Transaction list and total tab instead of last month added this year tab 
- [x] Add tab bar at top with 3 options All, Settled, Unsettled for the filtering in group list
- [x] On long press of group item show bottom sheet with edit and delete group options on the group list screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `ScrollToTopButton` for easier navigation in long lists.
  - Added a new `HeightModifier` to dynamically adjust view height.

- **Bug Fixes**
  - Improved handling of potential nil values in date properties across various views.
  - Enhanced error messages in payment validation.

- **Improvements**
  - Updated transaction filtering logic to use the current year instead of last month.
  - Disabled auto-capitalization for OTP text input for a better user experience.
  - Simplified logic in `AddExpenseViewModel` by removing unnecessary group-related parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->