### PR TITLE
Show last selected group id in add expense

### DIFF
--- a/Data/Data/Extension/Array+Extension.swift
+++ b/Data/Data/Extension/Array+Extension.swift
@@ -21,7 +21,8 @@ public extension Array where Element: Hashable {
     }
 
     func chunked(into size: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: size).map {
+        guard size > 0 else { return [] }
+        return stride(from: 0, to: count, by: size).map {
             Array(self[$0..<Swift.min($0 + size, count)])
         }
     }

--- a/Data/Data/Model/Expense.swift
+++ b/Data/Data/Model/Expense.swift
@@ -11,11 +11,11 @@ public struct Expense: Codable, Hashable, Identifiable {
 
     public var id: String? // Automatically generated ID by Firestore
 
-    public var groupId: String
+    public var groupId: String? = ""
     public var name: String
     public var amount: Double
-    public var currencyCode: String
-    public var category: String
+    public var category: String? = "General"
+    public var currencyCode: String? = "INR"
     public var date: Timestamp
     public let addedBy: String
     public var updatedAt: Timestamp?
@@ -26,19 +26,19 @@ public struct Expense: Codable, Hashable, Identifiable {
     public var splitTo: [String] // Reference to user ids involved in the split
     public var splitData: [String: Double]? // User Id with the split amount based on the split type
     public var paidBy: [String: Double] // [userId: paid amount]
-    public var comments: [Comments]
-    public var participants: [String] // List of user ids, Used for searching expenses by user
+    public var comments: [Comments]? = [] // List of comments for the expense
+    public var participants: [String]? = [] // List of user ids, Used for searching expenses by user
     public var isActive: Bool
 
-    public init(groupId: String, name: String, amount: Double, currencyCode: String = "INR", category: String  = "General",
+    public init(groupId: String, name: String, amount: Double, category: String  = "General", currencyCode: String = "INR",
                 date: Timestamp, addedBy: String, updatedAt: Timestamp? = nil, updatedBy: String? = nil, note: String? = nil,
                 imageUrl: String? = nil, splitType: SplitType, splitTo: [String], splitData: [String: Double]? = nil,
                 paidBy: [String: Double], comments: [Comments] = [], participants: [String], isActive: Bool = true) {
         self.groupId = groupId
         self.name = name
         self.amount = amount
-        self.currencyCode = currencyCode
         self.category = category
+        self.currencyCode = currencyCode
         self.date = date
         self.addedBy = addedBy
         self.updatedAt = updatedAt

--- a/Data/Data/Model/Expense.swift
+++ b/Data/Data/Model/Expense.swift
@@ -11,7 +11,7 @@ public struct Expense: Codable, Hashable, Identifiable {
 
     public var id: String? // Automatically generated ID by Firestore
 
-    public var groupId: String? = ""
+    public var groupId: String?
     public var name: String
     public var amount: Double
     public var category: String? = "General"

--- a/Data/Data/Model/Groups.swift
+++ b/Data/Data/Model/Groups.swift
@@ -12,17 +12,17 @@ public struct Groups: Codable, Identifiable {
     @DocumentID public var id: String? // Automatically generated ID by Firestore
 
     public var name: String
-    public var type: GroupType
+    public var type: GroupType? = .splitExpense
     public var createdBy: String
     public var updatedBy: String?
     public var imageUrl: String?
     public var members: [String]
-    public var initialBalance: Double // for fund type group only
+    public var initialBalance: Double? = 0 // for fund type group only
     public var balances: [GroupMemberBalance]
     public let createdAt: Timestamp
     public var updatedAt: Timestamp
     public var hasExpenses: Bool
-    public var defaultCurrency: String
+    public var defaultCurrency: String? = "INR"
     public var isActive: Bool
 
     public init(name: String, type: GroupType = .splitExpense, createdBy: String, updatedBy: String? = nil,

--- a/Data/Data/Store/ExpenseStore.swift
+++ b/Data/Data/Store/ExpenseStore.swift
@@ -90,7 +90,9 @@ public class ExpenseStore: ObservableObject {
 
             let expenses = snapshot.documents.compactMap { document in
                 do {
-                    return try document.data(as: Expense.self)
+                    var expense = try document.data(as: Expense.self)
+                    expense.groupId = expense.groupId == nil ? document.reference.parent.parent?.documentID : expense.groupId
+                    return expense
                 } catch {
                     LogE("ExpenseStore: \(#function) Error decoding expense from document \(document.documentID): \(error.localizedDescription)")
                     return nil

--- a/Splito/UI/Home/ActivityLog/Search/ExpensesSearchViewModel.swift
+++ b/Splito/UI/Home/ActivityLog/Search/ExpensesSearchViewModel.swift
@@ -2,7 +2,7 @@
 //  ExpensesSearchViewModel.swift
 //  Splito
 //
-//  Created by Nirali Sonani on 30/12/24.
+//  Created by Amisha Italiya on 30/12/24.
 //
 
 import Data
@@ -169,18 +169,16 @@ class ExpensesSearchViewModel: BaseViewModel, ObservableObject {
     }
 
     func fetchGroupBalance() {
-        withAnimation(.easeOut) { [weak self] in
+        withAnimation { [weak self] in
             guard let self else { return }
-            DispatchQueue.main.async {
-                self.viewState = self.expenses.isEmpty ? .noExpense : .hasExpense
-            }
+            self.viewState = self.expenses.isEmpty ? .noExpense : .hasExpense
         }
     }
 
     // MARK: - User Actions
     func handleExpenseItemTap(expense: Expense) {
-        if let expenseId = expense.id {
-            router.push(.ExpenseDetailView(groupId: expense.groupId, expenseId: expenseId))
+        if let expenseId = expense.id, let groupId = expense.groupId {
+            router.push(.ExpenseDetailView(groupId: groupId, expenseId: expenseId))
         }
     }
 

--- a/Splito/UI/Home/Expense/Detail Selection/Expense Split Option/ExpenseSplitOptionsTabView.swift
+++ b/Splito/UI/Home/Expense/Detail Selection/Expense Split Option/ExpenseSplitOptionsTabView.swift
@@ -173,8 +173,7 @@ private struct PercentageView: View {
                     ),
                     member: member, suffixText: "%",
                     isLastCell: member == viewModel.groupMembers.last,
-                    splitAmount: calculatePercentageSplitAmount(memberId: member.id, amount: viewModel.expenseAmount,
-                                                                splitTo: viewModel.selectedMembers, splitData: viewModel.percentages),
+                    splitAmount: viewModel.calculateFixedAmountForMember(memberId: member.id),
                     expenseAmount: viewModel.expenseAmount,
                     onChange: { percentage in
                         viewModel.updatePercentage(for: member.id, percentage: percentage)
@@ -200,8 +199,7 @@ private struct ShareView: View {
                     ),
                     member: member, suffixText: "shares",
                     isLastCell: member == viewModel.groupMembers.last,
-                    splitAmount: calculateSharesSplitAmount(memberId: member.id, amount: viewModel.expenseAmount,
-                                                            splitTo: viewModel.selectedMembers, splitData: viewModel.shares),
+                    splitAmount: viewModel.calculateFixedAmountForMember(memberId: member.id),
                     expenseAmount: viewModel.expenseAmount,
                     onChange: { share in
                         viewModel.updateShare(for: member.id, share: share)

--- a/Splito/UI/Home/Groups/GroupListView.swift
+++ b/Splito/UI/Home/Groups/GroupListView.swift
@@ -117,7 +117,7 @@ struct GroupListView: View {
                 .presentationCornerRadius(24)
         }
         .fullScreenCover(isPresented: $viewModel.showAddExpenseSheet) {
-            ExpenseRouteView()
+            ExpenseRouteView(selectedGroupId: viewModel.selectedGroup?.id)
         }
         .fullScreenCover(isPresented: $viewModel.showCreateGroupSheet) {
             NavigationStack {

--- a/Splito/UI/Home/Groups/GroupListViewModel.swift
+++ b/Splito/UI/Home/Groups/GroupListViewModel.swift
@@ -279,13 +279,14 @@ extension GroupListViewModel {
     }
 
     func handleGroupItemTap(_ group: Groups, isTapped: Bool = true) {
+        selectedGroup = group
         if isTapped {
             onSearchBarCancelBtnTap()
             if let id = group.id {
                 router.push(.GroupHomeView(groupId: id))
             }
         } else {
-            handleGroupItemLongPress(group)
+            showActionSheet = true
         }
     }
 
@@ -326,11 +327,6 @@ extension GroupListViewModel {
 
     func manageScrollToTopBtnVisibility(offset: CGFloat) {
         showScrollToTopBtn = offset < 0
-    }
-
-    func handleGroupItemLongPress(_ group: Groups) {
-        selectedGroup = group
-        showActionSheet = true
     }
 
     func handleOptionSelection(with selection: OptionList) {


### PR DESCRIPTION
- [x] Open add expense with last selected groupId from home
- [x] Fix: when equally type selected & unselect any member & switch tab then not getting split amount for that member in shares and percentages 

https://github.com/user-attachments/assets/ceda353d-f33d-4e95-8d70-57ef0bb7b70c

https://github.com/user-attachments/assets/7c708028-1880-4731-9313-7a28e88ca4bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced expense splitting functionality with fixed amount calculations for more accurate distribution.
  - Improved group selection handling in the expense management interface.
  - Introduced a search functionality within the activity log for easier expense tracking.
  - Added a new view for searching and displaying expenses, enhancing user interaction.

- **Bug Fixes**
  - Refined group item interaction logic to streamline user experience.
  - Updated expense routing to ensure it reflects the selected group context.

- **Refactor**
  - Streamlined calculation methods for expense splitting.
  - Simplified handling of group item taps by removing long press functionality.
  - Adjusted view model method visibility and return types for clarity.
  - Enhanced the structure and readability of the Add Expense view model for better data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->